### PR TITLE
Introduce a CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: Test build
+
+on:
+  push:
+    branches-ignore:
+    - _**
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: [self-hosted, linux, X64]
+    container:
+      image: mtzguido/pulse-base-devcontainer
+    defaults:
+      run:
+        # Setting the default shell to bash. This is not only more standard,
+        # but also makes sure that we run with -o pipefail, so we can safely
+        # pipe data (such as | tee LOG) without missing out on failures
+        # and getting false positives. If you want to change the default shell,
+        # keep in mind you need a way to handle this.
+        shell: bash
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+        
+      # FIXME: Why is $HOME badly set?
+      - name: Setup HOME and PATH
+        run: |
+          echo "HOME=/home/vscode" >> $GITHUB_ENV
+          echo "PATH=/home/vscode/bin:$PATH" >> $GITHUB_ENV
+
+      # This doesn't work. $GITHUB_ENV is not sourced, it must be of the
+      # shape K=V, but opam env prints stuff like 'export' directives.
+      # So, instead, call eval $(opam env) in every step.
+      # - run: opam env --set-switch >> $GITHUB_ENV
+
+      # If these fail, stop right now.
+      - run: which fstar.exe
+      - run: which z3
+
+      - name: Run CI Makefile rule
+        run: |
+          eval $(opam env)
+          make -skj$(nproc) ci

--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,8 @@ pull-pulse:
 
 .depend: $(ROOTS) pulse
 	$(FSTAR) --dep full $(ROOTS) --output_deps_to $@
+
+.PHONY: ci
+ci:
+	$(MAKE) update-pulse
+	$(MAKE) all

--- a/Makefile
+++ b/Makefile
@@ -1,47 +1,16 @@
 PULSE_REPO := https://github.com/FStarLang/pulse
 PULSE_HASH := $(shell cat .pulse.hash)
 
-ROOTS := $(shell find src/ -name '*.fst' -o -name '*.fsti')
-
-CACHEDIR := .cache
-OUTDIR   := .out
-
-FSTAR_FLAGS += --cache_checked_modules
-FSTAR_FLAGS += --cache_dir $(CACHEDIR)
-FSTAR_FLAGS += --odir $(OUTDIR)
-FSTAR_FLAGS += $(OTHERFLAGS)
-
-FSTAR := fstar.exe					\
-	--include pulse/lib/pulse/			\
-	--include pulse/lib/pulse/core/			\
-	--include pulse/lib/pulse/lib/			\
-	--include pulse/lib/pulse/lib/class/		\
-	--include src/lib/				\
-	--include src/examples/				\
-	--load_cmxs pulse				\
-	--warn_error -249-321				\
-	$(FSTAR_FLAGS)
-
-# This sandwich is needed so all is the first rule (and not
-# something in the include), and verify-all can refer to ALL_CHECKED_FILES,
-# which is empty before including .depend. Sigh.
-# We also need to allow calling make update-pulse without requiring
-# .depend,
+.PHONY: all
 all: verify-all
-ifeq ($(MAKECMDGOALS),update-pulse)
-else
-include .depend
-endif
-verify-all: $(ALL_CHECKED_FILES)
 
-# Dependencies come from .depend. We still need this rule.
-%.checked:
-	$(FSTAR) $<
-	@touch -c $@
+.PHONY: verify-all
+verify-all: pulse
+	$(MAKE) -f Makefile.verify $@
 
 .PHONY: echo-fstar
-echo-fstar:
-	@echo $(FSTAR)
+echo-fstar: pulse
+	$(MAKE) -f Makefile.verify $@
 
 pulse:
 	$(error pulse directory not found: Run `make update-pulse` to fetch and compile Pulse)
@@ -61,9 +30,6 @@ save-pulse:
 pull-pulse:
 	git -C pulse pull
 	$(MAKE) save-pulse
-
-.depend: $(ROOTS) pulse
-	$(FSTAR) --dep full $(ROOTS) --output_deps_to $@
 
 .PHONY: ci
 ci:

--- a/Makefile.verify
+++ b/Makefile.verify
@@ -1,0 +1,43 @@
+ROOTS := $(shell find src/ -name '*.fst' -o -name '*.fsti')
+
+CACHEDIR := .cache
+OUTDIR   := .out
+
+FSTAR_FLAGS += --cache_checked_modules
+FSTAR_FLAGS += --cache_dir $(CACHEDIR)
+FSTAR_FLAGS += --odir $(OUTDIR)
+FSTAR_FLAGS += $(OTHERFLAGS)
+
+FSTAR := fstar.exe					\
+	--include pulse/lib/pulse/			\
+	--include pulse/lib/pulse/core/			\
+	--include pulse/lib/pulse/lib/			\
+	--include pulse/lib/pulse/lib/class/		\
+	--include src/lib/				\
+	--include src/examples/				\
+	--load_cmxs pulse				\
+	--warn_error -249-321				\
+	$(FSTAR_FLAGS)
+
+# This sandwich is needed so all is the first rule (and not
+# something in the include), and verify-all can refer to ALL_CHECKED_FILES,
+# which is empty before including .depend. Sigh.
+all: verify-all
+include .depend
+verify-all: $(ALL_CHECKED_FILES)
+	# ^ This is a bit excessive since it will traverse interfaces
+	# and add them too. But I don't want do $(patsubst...) to turn
+	# the $(ROOTS) into .checked, since it involves choosing the
+	# directory too and that is the job of --dep.
+
+# Dependencies come from .depend. We still need this rule.
+%.checked:
+	$(FSTAR) $<
+	@touch -c $@
+
+.PHONY: echo-fstar
+echo-fstar:
+	@echo $(FSTAR)
+
+.depend: $(ROOTS)
+	$(FSTAR) --dep full $(ROOTS) --output_deps_to $@


### PR DESCRIPTION
cc @JonasAlaif, pretty basic but seems to work. It starts from a base container with F* installed so it's relatively fast.

One problem with that is that the F* version is fixed, it will not track master. If Pulse requires a newer F* to build, I have to rebuild that container manually (I could maybe also add an action to do it from the web UI). Just a heads up, I think it's fine for now.

Should we maybe lock the `main` branch to only push commits that pass CI?