### PR TITLE
use -f in verify.mk, just to be safe

### DIFF
--- a/verify.mk
+++ b/verify.mk
@@ -80,6 +80,7 @@ FSTAR_FLAGS += --ext no_krml_private
 FSTAR_FLAGS += --ext krml_inline_all
 FSTAR_FLAGS += $(OTHERFLAGS)
 FSTAR_FLAGS += $(FSTAR_DEBUG)
+FSTAR_FLAGS += -f # prevent stupid caching
 
 FSTAR = $(FSTAR_EXE)				\
 	$(SIL)						\


### PR DESCRIPTION
Somehow this breaks the build very badly, investigate
``` 
$ make -f verify.mk  out/Kuiper_Mul.cu
make: Circular .cache/FStar.Real.fsti.checked <- .cache/FStar.Real.fsti.checked dependency dropped.
  EXTRACT   .cache/Kuiper.Mul.fst.checked
* Error 276 at src/examples/Kuiper.Mul.fst:14.1-16.59:
  - Unexpected output from Z3:
      "(error "line 40751 column 27: Wrong number of arguments (1) passed to function (declare-fun FStar.UInt64.t () Term)")
      (error "line 42058 column 47: Wrong number of arguments (1) passed to function (declare-fun FStar.UInt64.t () Term)")"

make: *** [verify.mk:165: out/Kuiper_Mul.krml] Error 1
```
along many other errors