### PR TITLE
Remove the dangerous SZ.t ~> erased nat coercions

### DIFF
--- a/src/examples/Kuiper.Mul.fst
+++ b/src/examples/Kuiper.Mul.fst
@@ -31,7 +31,7 @@ fn kf (#size : erased nat{size > 0}) (* do NOT use erased pos, inference suffers
   let v1 = gpu_array_read #_ #_ #0 #size a1 bid;
   let v2 = gpu_array_read #_ #_ #0 #size a2 bid;
   let v = FStar.UInt64.(v1 *%^ v2);
-  gpu_array_write #_ #_ #bid #(bid + 1) ar bid v;
+  gpu_array_write #_ #_ #(hide #nat bid) #(bid + 1) ar bid v;
   (**)with sr. assert gpu_pts_to_slice ar bid (bid + 1) sr;
   (**)Seq.lemma_eq_intro sr seq![(smul s1 s2).[bid]];
   ()

--- a/src/examples/Kuiper.Reduction.fst
+++ b/src/examples/Kuiper.Reduction.fst
@@ -72,7 +72,7 @@ fn copy_to_gpu
   {| d : sized t |}
   (sz : sz)
   (a : vec t)
-  (#v : erased (seq t){len v == reveal sz})
+  (#v : erased (seq t){len v == SZ.v sz})
   preserves cpu ** (a |-> v)
   requires emp
   returns  ga : GA.gpu_array t sz

--- a/src/lib/data/Kuiper.EMatrix.fsti
+++ b/src/lib/data/Kuiper.EMatrix.fsti
@@ -9,7 +9,7 @@ module F = FStar.FunctionalExtensionality
 
 [@@erasable]
 noeq
-type ematrix (et:Type) (rows cols : erased nat) =
+type ematrix (et:Type) (rows cols : nat) =
   | M : f:(natlt rows & natlt cols ^->> et)
      -> ematrix et rows cols
 

--- a/src/lib/data/Kuiper.Matrix.Common.fsti
+++ b/src/lib/data/Kuiper.Matrix.Common.fsti
@@ -36,7 +36,7 @@ instance ematrix_is_ghost_map
   }
 
 let aview_from_mlayout
-  (et : Type) (#rows #cols : erased nat)
+  (et : Type) (#rows #cols : nat)
   (l : mlayout rows cols)
   : V.aview et (ematrix et rows cols) =
 let open Kuiper.Bijection in

--- a/src/lib/data/Kuiper.Matrix.Reprs.Type.fsti
+++ b/src/lib/data/Kuiper.Matrix.Reprs.Type.fsti
@@ -9,7 +9,7 @@ module SZ = FStar.SizeT
 
 [@@erasable]
 noeq
-type mlayout (rows cols : erased nat) = {
+type mlayout (rows cols : nat) = {
   len : nat;
   map : natlt rows & natlt cols @~> natlt len;
 }
@@ -17,7 +17,7 @@ type mlayout (rows cols : erased nat) = {
 let is_full_layout (l : mlayout 'rows 'cols) : prop =
   is_surj l.map.f
 
-let full_mlayout (rows cols : erased nat) =
+let full_mlayout (rows cols : nat) =
   l : mlayout rows cols { is_full_layout l }
 
 #push-options "--warn_error -288"
@@ -33,8 +33,7 @@ let full_layout_size #rows #cols (l : mlayout rows cols)
           [SMTPat (is_full_layout l)]
   = admit()
 
-(* erased helps *)
-let mlayout_size (#rows #cols : erased nat) (l : mlayout rows cols) : GTot nat =
+let mlayout_size (#rows #cols : nat) (l : mlayout rows cols) : GTot nat =
   l.len
 
 inline_for_extraction

--- a/src/lib/data/Kuiper.Matrix.fst
+++ b/src/lib/data/Kuiper.Matrix.fst
@@ -45,7 +45,7 @@ let gpu_matrix_pts_to
 ghost
 fn gpu_matrix_pts_to_ref
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (#l : mlayout rows cols)
   (g : gpu_matrix et l)
   (#f : perm)
@@ -64,7 +64,7 @@ fn gpu_matrix_pts_to_ref
 ghost
 fn gpu_matrix_concr
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (#l : mlayout rows cols { is_full_layout l })
   (g : gpu_matrix et l)
   (#em : ematrix et rows cols)
@@ -86,7 +86,7 @@ fn gpu_matrix_concr
 ghost
 fn gpu_matrix_abs
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (l : mlayout rows cols { is_full_layout l })
   (p : gpu_array et (mlayout_size l))
   (#f : perm)
@@ -106,7 +106,7 @@ fn gpu_matrix_abs
 ghost
 fn gpu_matrix_abs'
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (l : mlayout rows cols { is_full_layout l })
   (p : gpu_array et (mlayout_size l))
   (#f : perm)
@@ -140,6 +140,8 @@ fn gpu_matrix_alloc0
   fold gpu_matrix_pts_to gm s;
   gm;
 }
+
+#set-options "--print_implicits"
 
 inline_for_extraction noextract
 fn gpu_matrix_free

--- a/src/lib/data/Kuiper.Matrix.fsti
+++ b/src/lib/data/Kuiper.Matrix.fsti
@@ -96,7 +96,7 @@ instance has_pts_to_matrix (a:Type) (rows cols : erased nat) (l : _)
 ghost
 fn gpu_matrix_pts_to_ref
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (#l : mlayout rows cols)
   (g : gpu_matrix et l)
   (#f : perm)
@@ -109,7 +109,7 @@ fn gpu_matrix_pts_to_ref
 ghost
 fn gpu_matrix_concr
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (#l : mlayout rows cols { is_full_layout l })
   (g : gpu_matrix et l)
   (#em : ematrix et rows cols)
@@ -122,7 +122,7 @@ fn gpu_matrix_concr
 ghost
 fn gpu_matrix_abs
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (l : mlayout rows cols { is_full_layout l })
   (p : gpu_array et (mlayout_size l))
   (#f : perm)
@@ -135,7 +135,7 @@ fn gpu_matrix_abs
 ghost
 fn gpu_matrix_abs'
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (l : mlayout rows cols { is_full_layout l })
   (p : gpu_array et (mlayout_size l))
   (#f : perm)

--- a/src/lib/data/Kuiper.Matrix4.fsti
+++ b/src/lib/data/Kuiper.Matrix4.fsti
@@ -14,7 +14,7 @@ module SZ = FStar.SizeT
    layout stuff. *)
 unfold
 inline_for_extraction noextract
-type mlayout4 (mrows mcols brows bcols : erased nat) =
+type mlayout4 (mrows mcols brows bcols : nat) =
   l : mlayout (mrows * brows) (mcols * bcols) { is_full_layout l }
 
 inline_for_extraction noextract

--- a/src/lib/ghost/Kuiper.Ghost.Transpose.fst
+++ b/src/lib/ghost/Kuiper.Ghost.Transpose.fst
@@ -12,7 +12,7 @@ open Kuiper.Injection
 ghost
 fn ghost_transpose1
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (gA : gpu_matrix et (Repr.row_major rows cols))
   (#m : ematrix et rows cols)
   requires
@@ -33,7 +33,7 @@ fn ghost_transpose1
 ghost
 fn ghost_transpose2
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (gA : gpu_matrix et (Repr.col_major rows cols))
   (#m : ematrix et rows cols)
   requires
@@ -53,7 +53,7 @@ fn ghost_transpose2
 ghost
 fn ghost_transpose1_back
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (gA : gpu_matrix et (Repr.row_major rows cols))
   (#m : ematrix et cols rows)
   requires
@@ -72,7 +72,7 @@ fn ghost_transpose1_back
 ghost
 fn ghost_transpose2_back
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (gA : gpu_matrix et (Repr.col_major rows cols))
   (#m : ematrix et cols rows)
   requires

--- a/src/lib/ghost/Kuiper.Ghost.Transpose.fsti
+++ b/src/lib/ghost/Kuiper.Ghost.Transpose.fsti
@@ -26,7 +26,7 @@ let col2row
 ghost
 fn ghost_transpose1
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (gA : gpu_matrix et (Repr.row_major rows cols))
   (#m : ematrix et rows cols)
   requires
@@ -37,7 +37,7 @@ fn ghost_transpose1
 ghost
 fn ghost_transpose2
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (gA : gpu_matrix et (Repr.col_major rows cols))
   (#m : ematrix et rows cols)
   requires
@@ -48,7 +48,7 @@ fn ghost_transpose2
 ghost
 fn ghost_transpose1_back
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (gA : gpu_matrix et (Repr.row_major rows cols))
   (#m : ematrix et cols rows)
   requires
@@ -59,7 +59,7 @@ fn ghost_transpose1_back
 ghost
 fn ghost_transpose2_back
   (#et:Type)
-  (#rows #cols : erased nat)
+  (#rows #cols : nat)
   (gA : gpu_matrix et (Repr.col_major rows cols))
   (#m : ematrix et cols rows)
   requires

--- a/src/lib/kuiper/Kuiper.SizeT.fsti
+++ b/src/lib/kuiper/Kuiper.SizeT.fsti
@@ -35,9 +35,9 @@ let fits_sizet (x:nat)
 [@@coercion; pulse_unfold] unfold let sizet_to_nat  (x: SZ.t)  : GTot nat = SZ.v x
 [@@coercion; pulse_unfold] unfold let u32_to_nat    (x: U32.t) : GTot nat = U32.v x
 [@@coercion; pulse_unfold] unfold let u64_to_nat    (x: U64.t) : GTot nat = U64.v x
-[@@coercion; pulse_unfold] unfold let sizet_to_enat (x: SZ.t)  : erased nat = SZ.v x
-[@@coercion; pulse_unfold] unfold let u32_to_enat   (x: U32.t) : erased nat = U32.v x
-[@@coercion; pulse_unfold] unfold let u64_to_enat   (x: U64.t) : erased nat = U64.v x
+// [@@coercion; pulse_unfold] unfold let sizet_to_enat (x: SZ.t)  : erased nat = SZ.v x
+// [@@coercion; pulse_unfold] unfold let u32_to_enat   (x: U32.t) : erased nat = U32.v x
+// [@@coercion; pulse_unfold] unfold let u64_to_enat   (x: U64.t) : erased nat = U64.v x
 
 (* assumption, add to F*? *)
 val sizet_to_u32 (x: SZ.t)

--- a/src/lib/poly/Kuiper.Poly.AtomicReduce.fst
+++ b/src/lib/poly/Kuiper.Poly.AtomicReduce.fst
@@ -110,7 +110,7 @@ fn kf
   (a : gpu_array et (SZ.v nn))
   (#v_a : erased (seq et))
   (r : gpu_ref et)
-  (done : erased (seq (gref bool)){len done == reveal nn})
+  (done : erased (seq (gref bool)){len done == SZ.v nn})
   (i : iname)
   (bid : szlt (SZ.v nn))
   ()
@@ -123,7 +123,7 @@ fn kf
     kpost (SZ.v nn) a v_a r done i bid **
     block_id (SZ.v nn) bid
 {
-  assume (pure (len v_a == reveal nn));
+  assume (pure (len v_a == SZ.v nn));
   later_credit_buy 1;
   later_credit_buy 1;
   (* Read array at idx *)

--- a/src/lib/poly/Kuiper.Poly.DotProduct.fst
+++ b/src/lib/poly/Kuiper.Poly.DotProduct.fst
@@ -79,12 +79,12 @@ fn kf
 {
   (**)unfold (kpre lena ga1 ga2 s1 s2 tid);
 
-  let v1 = gpu_array_read #_ #_ #tid #(tid + 1) ga1 tid;
-  let v2 = gpu_array_read #_ #_ #tid #(tid + 1) ga2 tid;
+  let v1 = gpu_array_read ga1 tid;
+  let v2 = gpu_array_read ga2 tid;
 
   let vm = mul v1 v2;
 
-  gpu_array_write #_ #_ #tid #(tid + 1) ga1 tid vm;
+  gpu_array_write ga1 tid vm;
 
   (* Convince the SMT solver that these sequences are equal *)
   with s'.

--- a/src/lib/poly/Kuiper.Poly.HReduce.fst
+++ b/src/lib/poly/Kuiper.Poly.HReduce.fst
@@ -171,20 +171,21 @@ fn iteration
       if_elim_true _;
 
       (**)unfold (gpu_pts_to_slice_sum #et r tid nextid vv);
-      let s1 = gpu_array_read #et #_ #tid #nextid r tid;
+      (**)unfold (gpu_pts_to_slice_sum r nextid end_ vv);
+      (**)gpu_slice_concat #et #(SZ.v nth) r tid nextid end_;
+
+      let s1 = gpu_array_read r tid;
       (**)assert (pure (squash (is_reduction zero add (Seq.slice vv tid nextid) s1)));
 
-      (**)unfold (gpu_pts_to_slice_sum r nextid end_ vv);
-      let s2 = gpu_array_read #_ #_ #nextid #end_ r nextid;
+      let s2 = gpu_array_read r nextid;
       (**)assert (pure (squash (is_reduction zero add (Seq.slice vv nextid end_) s2)));
 
       let s = add s1 s2;
       (**)lem_append_slice vv tid nextid end_;
       (**)assert (pure (squash (is_reduction zero add (Seq.slice vv tid end_) s)));
 
-      gpu_array_write #et #(SZ.v nth) #(SZ.v tid) #(SZ.v nextid) r tid s;
+      gpu_array_write r tid s;
 
-      (**)gpu_slice_concat #et #(SZ.v nth) r tid nextid end_;
       (**)with seq. assert (gpu_pts_to_slice r tid end_ seq);
       (**)fold (gpu_pts_to_slice_sum r tid end_ vv);
       (**)if_intro_true (gpu_pts_to_slice_sum r tid end_ vv);

--- a/src/lib/poly/Kuiper.Poly.Softmax.fst
+++ b/src/lib/poly/Kuiper.Poly.Softmax.fst
@@ -49,9 +49,9 @@ fn kf_exp
   assert (pure (i < lena));
   assert (pure (SZ.v i == bid));
   unfold gpu_pts_to_array1 a i;
-  let x = gpu_array_read #_ #_ #i #(i+1) a i;
+  let x = gpu_array_read a i;
   let x = exp x;
-  gpu_array_write #_ #_ #i #(i+1) a i x;
+  gpu_array_write a i x;
   fold gpu_pts_to_array1 a i;
   rewrite each i as bid;
   ()
@@ -97,9 +97,9 @@ fn kf_div
   assert (pure (i < lena));
   assert (pure (SZ.v i == bid));
   unfold gpu_pts_to_array1 a i;
-  let x = gpu_array_read #_ #_ #i #(i+1) a i;
+  let x = gpu_array_read a i;
   let x = x `div` d;
-  gpu_array_write #_ #_ #i #(i+1) a i x;
+  gpu_array_write a i x;
   fold gpu_pts_to_array1 a i;
   rewrite each i as bid;
   ()

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.SHMem.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.SHMem.fst
@@ -86,7 +86,7 @@ let kpre1
   (gB |-> Frac (fB /. mlayout_size lC) eB) **
   (exists* v.
     gpu_matrix_pts_to_cell
-      (gpu_matrix_subtile gC tile tile (bid / mcols) (bid % mcols))
+      (gpu_matrix_subtile gC (SZ.v tile) (SZ.v tile) (bid / mcols) (bid % mcols))
       #1.0R
       (tid / tile) (tid % tile) v)
 
@@ -113,7 +113,7 @@ let kpost1
   (gB |-> Frac (fB /. mlayout_size lC) eB) **
   (exists* v.
     gpu_matrix_pts_to_cell
-      (gpu_matrix_subtile gC tile tile (bid / mcols) (bid % mcols))
+      (gpu_matrix_subtile gC (SZ.v tile) (SZ.v tile) (bid / mcols) (bid % mcols))
       #1.0R
       (tid / tile) (tid % tile) v)
 
@@ -237,8 +237,8 @@ fn kf
   let sa2 = M.from_array slB ar2;
   rewrite each M.from_array slB ar2 as sa2;
 
-  let gTile = gpu_matrix_subtile gC tile tile (bid / mcols) (bid % mcols);
-  assert (rewrites_to gTile (gpu_matrix_subtile gC tile tile (bid / mcols) (bid % mcols)));
+  let gTile = gpu_matrix_subtile gC (SZ.v tile) (SZ.v tile) (bid / mcols) (bid % mcols);
+  assert (rewrites_to gTile (gpu_matrix_subtile gC (SZ.v tile) (SZ.v tile) (bid / mcols) (bid % mcols)));
 
   let mrow, mcol = s_divmod mcols bid;
   let brow, bcol = s_divmod tile  tid;
@@ -267,11 +267,11 @@ fn kf
     let vbk = !bk;
 
     gpu_matrix_extract_tile gA tile tile mrow vbk;
-    let aTile = gpu_matrix_subtile gA tile tile mrow vbk;
-    assert (rewrites_to aTile (gpu_matrix_subtile gA tile tile mrow vbk));
+    let aTile = gpu_matrix_subtile gA (SZ.v tile) (SZ.v tile) (SZ.v mrow) (SZ.v vbk);
+    assert (rewrites_to aTile (gpu_matrix_subtile gA (SZ.v tile) (SZ.v tile) (SZ.v mrow) (SZ.v vbk)));
     gpu_matrix_extract_tile gB tile tile vbk mcol;
-    let bTile = gpu_matrix_subtile gB tile tile vbk mcol;
-    assert (rewrites_to bTile (gpu_matrix_subtile gB tile tile vbk mcol));
+    let bTile = gpu_matrix_subtile gB (SZ.v tile) (SZ.v tile) (SZ.v vbk) (SZ.v mcol);
+    assert (rewrites_to bTile (gpu_matrix_subtile gB (SZ.v tile) (SZ.v tile) (SZ.v vbk) (SZ.v mcol)));
 
     let v1 = M.gpu_matrix_read aTile brow bcol;
     let v2 = M.gpu_matrix_read bTile brow bcol;

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.Tiled.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.Tiled.fst
@@ -35,7 +35,7 @@ let kpre
   (gB |-> Frac fB eB) **
   (exists* v.
     gpu_matrix_pts_to_cell
-      (gpu_matrix_subtile gC tile tile (bid / mcols) (bid % mcols))
+      (gpu_matrix_subtile gC (SZ.v tile) (SZ.v tile) (bid / mcols) (bid % mcols))
       (tid / tile)
       (tid % tile)
       v)
@@ -99,9 +99,9 @@ fn kf
 
   with i0 j0 v0.
     rewrite
-      gpu_matrix_pts_to_cell (gpu_matrix_subtile gC tile tile (bid / mcols) (bid % mcols)) #1.0R i0 j0 v0
+      gpu_matrix_pts_to_cell (gpu_matrix_subtile gC (SZ.v tile) (SZ.v tile) (bid / mcols) (bid % mcols)) #1.0R i0 j0 v0
     as
-      gpu_matrix_pts_to_cell (gpu_matrix_subtile gC tile tile (bid / mcols) (bid % mcols)) #1.0R brow bcol v0
+      gpu_matrix_pts_to_cell (gpu_matrix_subtile gC (SZ.v tile) (SZ.v tile) (bid / mcols) (bid % mcols)) #1.0R brow bcol v0
     ;
 
   assert (pure (mrow < mrows));
@@ -109,8 +109,8 @@ fn kf
   assert (pure (brow < tile));
   assert (pure (bcol < tile));
 
-  let gTile = gpu_matrix_subtile gC tile tile (bid / mcols) (bid % mcols);
-  assert (rewrites_to gTile (gpu_matrix_subtile gC tile tile (bid / mcols) (bid % mcols)));
+  let gTile = gpu_matrix_subtile gC (SZ.v tile) (SZ.v tile) (bid / mcols) (bid % mcols);
+  assert (rewrites_to gTile (gpu_matrix_subtile gC (SZ.v tile) (SZ.v tile) (bid / mcols) (bid % mcols)));
 
   let s = MU.matmul_tiled_dotprod gA gB mrow mcol brow bcol;
   let v0 = gpu_matrix_read_cell gTile brow bcol;
@@ -118,10 +118,10 @@ fn kf
   gpu_matrix_write_cell gTile brow bcol v1;
 
   rewrite
-    gpu_matrix_pts_to_cell (gpu_matrix_subtile gC tile tile (bid / mcols) (bid % mcols))
+    gpu_matrix_pts_to_cell (gpu_matrix_subtile gC (SZ.v tile) (SZ.v tile) (bid / mcols) (bid % mcols))
       brow bcol v1
   as
-    gpu_matrix_pts_to_cell (gpu_matrix_subtile gC tile tile (bid / mcols) (bid % mcols))
+    gpu_matrix_pts_to_cell (gpu_matrix_subtile gC (SZ.v tile) (SZ.v tile) (bid / mcols) (bid % mcols))
       (tid / tile) (tid % tile) v1;
 
   ()

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.Util.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.Util.fst
@@ -84,7 +84,6 @@ fn matmul_tiled_dotprod
   let mut sum : et = zero;
   let mut bk  : sz = 0sz;
 
-
   while (SZ.(!bk <^ shared))
     invariant
       exists* (vbk : SZ.t) sumv.
@@ -97,22 +96,15 @@ fn matmul_tiled_dotprod
     assert (pure (bi  < (rows   * tile) / tile));
     assert (pure (vbk < (shared * tile) / tile));
     // Sigh.... need to reveal and hide. Terrible UX.
-    let tA = Tiling.gpu_matrix_subtile gA tile tile (hide (reveal bi)) (hide (reveal vbk));
-    let tB = Tiling.gpu_matrix_subtile gB tile tile (hide (reveal vbk)) (hide (reveal bj));
-    assert (rewrites_to tA (Tiling.gpu_matrix_subtile gA tile tile (hide (reveal bi)) (hide (reveal vbk))));
-    assert (rewrites_to tB (Tiling.gpu_matrix_subtile gB tile tile (hide (reveal vbk)) (hide (reveal bj))));
+    let tA = Tiling.gpu_matrix_subtile gA (SZ.v tile) (SZ.v tile) (SZ.v bi) (SZ.v vbk);
+    let tB = Tiling.gpu_matrix_subtile gB (SZ.v tile) (SZ.v tile) (SZ.v vbk) (SZ.v bj);
+    assert (rewrites_to tA (Tiling.gpu_matrix_subtile gA (SZ.v tile) (SZ.v tile) (SZ.v bi) (SZ.v vbk)));
+    assert (rewrites_to tB (Tiling.gpu_matrix_subtile gB (SZ.v tile) (SZ.v tile) (SZ.v vbk) (SZ.v bj)));
 
     Tiling.gpu_matrix_extract_tile gA tile tile bi vbk;
     Tiling.gpu_matrix_extract_tile gB tile tile vbk bj;
 
-    let s' = matmul_dotprod
-      #_ #_
-      #tile #tile #tile
-      // #(Tiling.subtile_layout lA tile tile bi vbk)
-      // #(Tiling.subtile_layout lB tile tile vbk bj)
-      // #(Tiling.c_subtile_layout #_ #_ _ #_ _ _ _ _ #_ #_ #_ #_)
-      // #(Tiling.c_subtile_layout #_ #_ _ #_ _ _ _ _ #_ #_ #_ #_)
-      tA tB i j;
+    let s' = matmul_dotprod tA tB i j;
     sum := !sum `add` s';
 
     ambig_trade_elim ();

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMMCPU.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMMCPU.fst
@@ -165,9 +165,9 @@ fn _OLD_mmcomb_gpu_tiled
   let lA4 : mlayout4 mrows   mshared tile tile = lA;
   let lB4 : mlayout4 mshared mcols  tile tile = lB;
   let lC4 : mlayout4 mrows   mcols  tile tile = lC;
-  let gA4 = MC.m2_to_m4 tile tile mrows   mshared gA;
-  let gB4 = MC.m2_to_m4 tile tile mshared mcols   gB;
-  let gC4 = MC.m2_to_m4 tile tile mrows   mcols   gC;
+  let gA4 = MC.m2_to_m4 (SZ.v tile) (SZ.v tile) (SZ.v mrows)   (SZ.v mshared) gA;
+  let gB4 = MC.m2_to_m4 (SZ.v tile) (SZ.v tile) (SZ.v mshared) (SZ.v mcols)   gB;
+  let gC4 = MC.m2_to_m4 (SZ.v tile) (SZ.v tile) (SZ.v mrows)   (SZ.v mcols)   gC;
   tiled_mmcomb_gpu tile
     comb
     lA4 lB4 lC4
@@ -237,9 +237,9 @@ fn mmcomb_gpu_block_tiled1d
   let lA4 : mlayout4 mrows   mshared bm bk = lA;
   let lB4 : mlayout4 mshared mcols  bk bn = lB;
   let lC4 : mlayout4 mrows   mcols  bm bn = lC;
-  let gA4 = MC.m2_to_m4 bm bk mrows mshared gA;
-  let gB4 = MC.m2_to_m4 bk bn mshared mcols gB;
-  let gC4 = MC.m2_to_m4 bm bn mrows mcols gC;
+  let gA4 = MC.m2_to_m4 (SZ.v bm) (SZ.v bk) (SZ.v mrows) (SZ.v mshared) gA;
+  let gB4 = MC.m2_to_m4 (SZ.v bk) (SZ.v bn) (SZ.v mshared) (SZ.v mcols) gB;
+  let gC4 = MC.m2_to_m4 (SZ.v bm) (SZ.v bn) (SZ.v mrows) (SZ.v mcols) gC;
   tiled_mmcomb_gpu
     comb
     bm bn bk
@@ -313,9 +313,9 @@ fn mmcomb_gpu_shmem_block_tiled2d
   let lA4 : mlayout4 mrows   mshared bm bk = lA;
   let lB4 : mlayout4 mshared mcols  bk bn = lB;
   let lC4 : mlayout4 mrows   mcols  bm bn = lC;
-  let gA4 = MC.m2_to_m4 bm bk mrows mshared gA;
-  let gB4 = MC.m2_to_m4 bk bn mshared mcols gB;
-  let gC4 = MC.m2_to_m4 bm bn mrows mcols gC;
+  let gA4 = MC.m2_to_m4 (SZ.v bm) (SZ.v bk) (SZ.v mrows) (SZ.v mshared) gA;
+  let gB4 = MC.m2_to_m4 (SZ.v bk) (SZ.v bn) (SZ.v mshared) (SZ.v mcols) gB;
+  let gC4 = MC.m2_to_m4 (SZ.v bm) (SZ.v bn) (SZ.v mrows) (SZ.v mcols) gC;
 
   // There is no way to prove this.
   assume (pure (SZ.fits (bm*bk + (bm/tm * (bn/tn)))));


### PR DESCRIPTION
These kick in when we do not want them to (e.g. if the expected type is erased bool). Just kill them. Things look more predictable now, but this may just be a first impression (or caused by previous changes). I also changed `erased nat` to `nat` in many types and ghost functions, which is the right thing to do, and now it does in fact seem to work.

cc @bastian-koepcke 