### PR TITLE
Remove pull axiom.

### DIFF
--- a/src/examples/Kuiper.ArrayView.Test.EvenOdds.fst
+++ b/src/examples/Kuiper.ArrayView.Test.EvenOdds.fst
@@ -63,10 +63,7 @@ instance _cview_even #et (len : erased nat) (sz_len : concrete_sz len) : IView.c
     bij  = natural;
   };
   step = {
-    cimap = {
-      f = (fun (i : szlt ((len + 1) / 2)) -> i `SZ.mul` 2sz <: szlt len);
-      is_inj = ez;
-    };
+    cimap = mk_cinj (fun (i : szlt ((len + 1) / 2)) -> i `SZ.mul` 2sz <: szlt len);
     compat = ez;
   };
 }
@@ -79,10 +76,7 @@ instance _cview_odd #et (len : erased nat) (sz_len : concrete_sz len) : IView.ci
     bij  = natural;
   };
   step = {
-    cimap = {
-      f = (fun (i : szlt (len / 2)) -> 1sz +^ i `SZ.mul` 2sz <: szlt len);
-      is_inj = ez;
-    };
+    cimap = mk_cinj (fun (i : szlt (len / 2)) -> 1sz +^ i `SZ.mul` 2sz <: szlt len);
     compat = ez;
   };
 }

--- a/src/examples/Kuiper.ArrayView.Test.EvenOdds2.fst
+++ b/src/examples/Kuiper.ArrayView.Test.EvenOdds2.fst
@@ -66,10 +66,7 @@ instance _cview_even #et
     bij    = natural;
   };
   step = {
-    cimap = {
-      f = (fun (i : szlt ((len + 1) / 2)) -> i `SZ.mul` 2sz <: szlt len);
-      is_inj = ez;
-    };
+    cimap = mk_cinj (fun (i : szlt ((len + 1) / 2)) -> i `SZ.mul` 2sz <: szlt len);
     compat = ez;
   };
 }
@@ -85,10 +82,7 @@ instance _cview_odd #et
     bij  = natural;
   };
   step = {
-    cimap = {
-      f = (fun (i : szlt (len / 2)) -> 1sz `SZ.add` (i `SZ.mul` 2sz) <: szlt len);
-      is_inj = ez;
-    };
+    cimap = mk_cinj (fun (i : szlt (len / 2)) -> 1sz `SZ.add` (i `SZ.mul` 2sz) <: szlt len);
     compat = ez;
   };
 }
@@ -205,7 +199,7 @@ let lem_idx2 #et (#len : nat) (i : natlt len{i % 2 = 1})
   : Lemma (it_of_nat (sum_aview (even_view et len) (odd_view et len)) i == Inr #(natlt ((len + 1)/ 2)) #(natlt (len / 2)) (i / 2))
 = admit()
 
-#push-options "--split_queries always"
+#push-options "--split_queries always --z3rlimit 10"
 let merge_lemma #et (#len:nat) (sl : lseq et ((len + 1) / 2)) (sr : lseq et (len / 2))
   : Lemma (
             to_seq (sum_aview (even_view et len) (odd_view et len)) (sl, sr)

--- a/src/examples/Kuiper.ArrayView.Test.EvenOdds3.fst
+++ b/src/examples/Kuiper.ArrayView.Test.EvenOdds3.fst
@@ -53,10 +53,8 @@ instance _cview_strided
     bij  = natural;
   };
   step = {
-    cimap = {
-      f = (fun (i : szlt ((len + stride - 1 - offset) / stride)) -> i `SZ.mul` stride `SZ.add` offset <: szlt len);
-      is_inj = ez;
-    };
+    cimap = mk_cinj
+      (fun (i : szlt ((len + stride - 1 - offset) / stride)) -> i `SZ.mul` stride `SZ.add` offset <: szlt len);
     compat = ez;
   };
 }

--- a/src/examples/Kuiper.ArrayView.Test.EvenOdds4.fst
+++ b/src/examples/Kuiper.ArrayView.Test.EvenOdds4.fst
@@ -74,10 +74,8 @@ let strided_cistep (len : erased nat{SZ.fits len}) (stride : sz) (offset : szlt 
     (raw_ciview_schema len)
     (strided_step len stride offset)
 = {
-  cimap = {
-    f = (fun (i : szlt ((len + stride - 1 - offset) / stride)) -> (i `SZ.mul` stride `SZ.add` offset) <: szlt len);
-    is_inj = ez;
-  };
+  cimap = mk_cinj
+    (fun (i : szlt ((len + stride - 1 - offset) / stride)) -> (i `SZ.mul` stride `SZ.add` offset) <: szlt len);
   compat = ez;
 }
 

--- a/src/examples/Kuiper.ArrayView.Test.Modulo.fst
+++ b/src/examples/Kuiper.ArrayView.Test.Modulo.fst
@@ -48,10 +48,7 @@ instance _cview_strided
     bij  = natural;
   };
   step = {
-    cimap = {
-      f = (fun (i : szlt ((len + stride - 1 - offset) / stride)) -> i `SZ.mul` stride `SZ.add` offset <: szlt len);
-      is_inj = ez;
-    };
+    cimap = mk_cinj (fun (i : szlt ((len + stride - 1 - offset) / stride)) -> i `SZ.mul` stride `SZ.add` offset <: szlt len);
     compat = ez;
   };
 }

--- a/src/examples/Kuiper.ArrayView.Test1.fst
+++ b/src/examples/Kuiper.ArrayView.Test1.fst
@@ -94,7 +94,7 @@ instance cnormal_view et (len : erased nat{SZ.fits len}) {| sz_len : concrete_sz
     bij      = natural;
   };
   step = {
-    cimap    = inj_id;
+    cimap    = cinj_id;
     compat   = ez;
   };
 }
@@ -107,12 +107,10 @@ instance creverse_view et (len : erased nat{SZ.fits len}) {| sz_len : concrete_s
     bij      = natural;
   };
   step = {
-    cimap    = {
+    cimap    =
       // Can't use imap = inj_sz_rev (SZ.uint_to_t len) for stupid reasons,
       // a type inside a refinement does not match exactly.
-      f = (fun (i : szlt len) -> concr' sz_len -^ 1sz -^ i <: szlt len);
-      is_inj = ez;
-    };
+      mk_cinj (fun (i : szlt len) -> concr' sz_len -^ 1sz -^ i <: szlt len);
     compat   = ez;
   };
 }

--- a/src/lib/common/Pulse.Lib.BigStar.fsti
+++ b/src/lib/common/Pulse.Lib.BigStar.fsti
@@ -251,14 +251,15 @@ fn bigstar_if_intro
   requires p x
   ensures  bigstar #u1 m n (fun (i:nat { m <= i /\ i < n }) -> cond (i = x) (p i) emp)
 
-class permutation (a:Type) = {
-   f          : a -> a;
-   g          : a -> a;
+[@@erasable]
+noeq type permutation (a:Type) = {
+   f          : a -> GTot a;
+   g          : a -> GTot a;
    [@@@FStar.Tactics.Typeclasses.no_method]
    proof : (x: a) -> (y: a) -> squash (f x == y <==> g y == x);
 }
 
-instance perm_inv (#a:Type) (p: permutation a) : permutation a = {
+let perm_inv (#a:Type) (p: permutation a) : permutation a = {
   f = p.g;
   g = p.f;
   proof = fun x y -> p.proof y x

--- a/src/lib/data/Kuiper.Matrix.Common.fsti
+++ b/src/lib/data/Kuiper.Matrix.Common.fsti
@@ -25,12 +25,12 @@ instance ematrix_is_ghost_map
   : is_ghost_map (ematrix et rows cols) (natlt rows & natlt cols) et
 = {
     bij = {
-      ff = (fun m -> M?.f (reveal m));
-      gg = (fun f -> hide (M f));
+      ff = (fun m -> M?.f m);
+      gg = (fun f -> M f);
       ff_gg = ez;
       gg_ff = ez;
     };
-    acc = (fun m (i, j) -> hide (macc m i j));
+    acc = (fun m (i, j) -> (macc m i j));
     upd = (fun m (i, j) x -> mupd m i j x);
     l1 = ez;
     l2 = ez;

--- a/src/lib/data/Kuiper.Matrix.fsti
+++ b/src/lib/data/Kuiper.Matrix.fsti
@@ -36,10 +36,7 @@ instance cview_from_clayout
   };
 
   step = {
-    cimap = {
-      f      = clayout_imap c;
-      is_inj = ez;
-    };
+    cimap = Kuiper.Injection.mk_cinj (clayout_imap c);
     compat = ez;
   };
 }

--- a/src/lib/data/Kuiper.Matrix4.fst
+++ b/src/lib/data/Kuiper.Matrix4.fst
@@ -5,6 +5,7 @@ open Kuiper
 open Kuiper.Bijection
 open Kuiper.GhostMap
 open Kuiper.EMatrix4
+open Kuiper.Injection { mk_cinj }
 module A = Kuiper.VArray
 module T = FStar.Tactics.V2
 open FStar.SizeT { (/^), (%^), (+^), (-^), ( *^ )  }
@@ -78,10 +79,7 @@ instance cview_from_clayout4
   };
 
   step = {
-    cimap = {
-      f = clayout4_imap c;
-      is_inj = (fun idx1 idx2 -> ());
-    };
+    cimap = mk_cinj (clayout4_imap c) #(fun idx1 idx2 -> ());
     compat = ez;
   };
 }

--- a/src/lib/data/array/Kuiper.IArray.fst
+++ b/src/lib/data/array/Kuiper.IArray.fst
@@ -298,6 +298,7 @@ fn iarray_reindex_
   ()
 }
 
+unobservable
 fn iarray_reindex
   (#et : Type0)
   (#vw : aiview)
@@ -440,12 +441,12 @@ fn iarray_write_cell
     Cell a (ci_to_ai vw ci) |-> v1
 {
   let ai : erased vw.sch.ait = ci |> cw.sch.bij.gg; (* abstract index *)
-  let ni = ci |~> cw.step.cimap;                    (* numerical index *)
+  let ni = cw.step.cimap.cf ci;                    (* numerical index *)
   rewrite each ci_to_ai vw ci as ai;
 
   cw.step.compat ai;
-  assert pure ((cw.step.cimap.f (cw.sch.bij.ff ai)) == SZ.uint_to_t (vw.step.imap.f ai));
-  assert pure (SZ.v (cw.step.cimap.f (cw.sch.bij.ff ai)) == vw.step.imap.f ai);
+  assert pure ((cw.step.cimap.cf (cw.sch.bij.ff ai)) == SZ.uint_to_t (vw.step.imap.f ai));
+  assert pure (SZ.v (cw.step.cimap.cf (cw.sch.bij.ff ai)) == vw.step.imap.f ai);
 
   unfold iarray_pts_to_cell a ai v0;
   rewrite each it_to_nat vw (reveal ai) as ni;
@@ -499,13 +500,13 @@ fn iarray_read_cell
     pure (v == v0)
 {
   let ai : erased vw.sch.ait = ci |> cw.sch.bij.gg; (* abstract index *)
-  let ni = ci |~> cw.step.cimap;                    (* numerical index *)
+  let ni = cw.step.cimap.cf ci;                    (* numerical index *)
   rewrite each ci_to_ai vw ci as ai;
 
   cw.step.compat ai;
-  assert pure ((cw.step.cimap.f (cw.sch.bij.ff ai)) == SZ.uint_to_t (vw.step.imap.f ai));
+  assert pure ((cw.step.cimap.cf (cw.sch.bij.ff ai)) == SZ.uint_to_t (vw.step.imap.f ai));
   (* ^ FIXME: this should be exactly what we get from the line above? *)
-  assert pure (SZ.v (cw.step.cimap.f (cw.sch.bij.ff ai)) == vw.step.imap.f ai);
+  assert pure (SZ.v (cw.step.cimap.cf (cw.sch.bij.ff ai)) == vw.step.imap.f ai);
 
   unfold iarray_pts_to_cell a #f ai v0;
   rewrite each it_to_nat vw (reveal ai) as ni;

--- a/src/lib/data/array/Kuiper.IArray.fsti
+++ b/src/lib/data/array/Kuiper.IArray.fsti
@@ -223,6 +223,7 @@ fn iarray_reindex_
     from_array (reindex_view vw bij) (core a) |-> Frac f (v `oo` bij.gg)
 
 inline_for_extraction noextract
+unobservable
 fn iarray_reindex
   (#et : Type0)
   (#vw : aiview)

--- a/src/lib/data/array/Kuiper.VArray.fst
+++ b/src/lib/data/array/Kuiper.VArray.fst
@@ -60,7 +60,7 @@ let varray_pts_to
   (v : st)
   : slprop
   =
-    (VA?._0 a) |-> Frac f (fun i -> reveal (vw.igm.acc v i))
+    (VA?._0 a) |-> Frac f (vw.igm.acc v)
 
 ghost
 fn varray_pts_to_ref
@@ -163,7 +163,7 @@ fn varray_reindex_
     (from_array (reindex_view vw bij) (core a))._0;
   IArray.iarray_ext (from_array (reindex_view vw bij) (core a))._0
     _
-    (fun i -> (reindex_view vw bij).igm.acc v i);
+    ((reindex_view vw bij).igm.acc v);
   fold varray_pts_to (from_array (reindex_view vw bij) (core a)) #f v;
   ()
 }
@@ -206,23 +206,23 @@ fn varray_review_
 {
   unfold varray_pts_to a #f v;
   IArray.iarray_ext a._0
-    (fun i -> vw.igm.acc v i)
-    (fun i -> (review_view vw bij).igm.acc (bij.ff v) i);
+    (vw.igm.acc v)
+    ((review_view vw bij).igm.acc (bij.ff v));
 
-  rewrite IArray.iarray_pts_to #et #vw.iview a._0 #f (fun i -> (review_view vw bij).igm.acc (bij.ff v) i)
+  rewrite IArray.iarray_pts_to #et #vw.iview a._0 #f ((review_view vw bij).igm.acc (bij.ff v))
        as IArray.iarray_pts_to #et #vw.iview
             (from_array (review_view vw bij) (core a))._0
             #f
-            (fun i -> (review_view vw bij).igm.acc (bij.ff v) i);
+            ((review_view vw bij).igm.acc (bij.ff v));
   assert pure (vw.iview == (review_view vw bij).iview);
   rewrite IArray.iarray_pts_to #et #vw.iview
             (from_array (review_view vw bij) (core a))._0
             #f
-            (fun i -> (review_view vw bij).igm.acc (bij.ff v) i)
+            ((review_view vw bij).igm.acc (bij.ff v))
        as IArray.iarray_pts_to #et #(review_view vw bij).iview
             (from_array (review_view vw bij) (core a))._0
             #f
-            (fun i -> (review_view vw bij).igm.acc (bij.ff v) i)
+            ((review_view vw bij).igm.acc (bij.ff v))
        by slprop_equiv_norm (); // ugly
   fold varray_pts_to (from_array (review_view vw bij) (core a)) #f (bij.ff v);
   ()
@@ -268,7 +268,7 @@ fn varray_begin_
     (from_array (raw_view #et #len) a)._0;
   IArray.iarray_ext _
     (IArray.g_seq_acc v)
-    (fun i -> (raw_view #et #len).igm.acc v i);
+    ((raw_view #et #len).igm.acc v);
   fold varray_pts_to (from_array (raw_view #et #len) a) #f v;
   ()
 }
@@ -471,7 +471,7 @@ fn varray_split2_
   IArray.iarray_ext
     (IArray.from_array vw1.iview (IArray.core a._0))
     (fun i -> (sum_aview vw1 vw2).igm.acc v (Inl i))
-    (fun i -> vw1.igm.acc (fst v) i);
+    (vw1.igm.acc (fst v));
   rewrite each (IArray.from_array vw1.iview (IArray.core a._0))
             as (from_array vw1 (core a))._0;
   fold varray_pts_to (from_array vw1 (core a)) #f (fst v);
@@ -479,7 +479,7 @@ fn varray_split2_
   IArray.iarray_ext
     (IArray.from_array vw2.iview (IArray.core a._0))
     (fun i -> (sum_aview vw1 vw2).igm.acc v (Inr i))
-    (fun i -> vw2.igm.acc (snd v) i);
+    (vw2.igm.acc (snd v));
   rewrite each (IArray.from_array vw2.iview (IArray.core a._0))
             as (from_array vw2 (core a))._0;
   fold varray_pts_to (from_array vw2 (core a)) #f (snd v);
@@ -576,7 +576,7 @@ fn varray_share_n
   IArray.iarray_share_n #_ #_ #uid (VA?._0 a) k;
   ghost
   fn aux (i : nat)
-    requires IArray.iarray_pts_to a._0 #(f /. k) (fun i -> vw.igm.acc v i)
+    requires IArray.iarray_pts_to a._0 #(f /. k) (vw.igm.acc v)
     ensures  varray_pts_to #et a #(f /. k) v
   {
     fold varray_pts_to a #(f /. k) v;
@@ -603,7 +603,7 @@ fn varray_gather_n
   ghost
   fn aux (i : nat)
     requires varray_pts_to #et a #(f /. k) v
-    ensures  IArray.iarray_pts_to a._0 #(f /. k) (fun i -> vw.igm.acc v i)
+    ensures  IArray.iarray_pts_to a._0 #(f /. k) (vw.igm.acc v)
   {
     unfold varray_pts_to a #(f /. k) v;
   };
@@ -751,7 +751,7 @@ fn varray_write
   vw.igm.l2 (ci_to_ai vw ci) v0 e;
   IArray.iarray_ext a._0
     _
-    (fun i -> vw.igm.acc (vw.igm.upd v0 (ci_to_ai vw ci) e) i);
+    (vw.igm.acc (vw.igm.upd v0 (ci_to_ai vw ci) e));
   fold varray_pts_to a (vw.igm.upd v0 (ci_to_ai vw ci) e);
   ()
 }

--- a/src/lib/data/array/Kuiper.VArray.fsti
+++ b/src/lib/data/array/Kuiper.VArray.fsti
@@ -19,7 +19,7 @@ let view_equiv (#et #st : Type)
   : prop
 = vw1.iview.len == vw2.iview.len /\
   vw1.iview.sch.ait == vw2.iview.sch.ait /\
-  F.feq vw1.iview.step.imap.f vw2.iview.step.imap.f /\
+  F.feq_g vw1.iview.step.imap.f vw2.iview.step.imap.f /\
   (* probably need more about the mappings in igm *)
   True
 

--- a/src/lib/kuiper/Kuiper.Bijection.fsti
+++ b/src/lib/kuiper/Kuiper.Bijection.fsti
@@ -13,10 +13,10 @@ need to mark some of these 'unfold'. Probably due
 to a limitation of the pulse checker. *)
 
 noeq
-inline_for_extraction noextract (* IMPORTANT! *)
+[@@erasable]
 type bijection (a b : Type) = {
-  ff : a -> b;
-  gg : b -> a;
+  ff : a -> GTot b;
+  gg : b -> GTot a;
 
   ff_gg : x:_ -> squash (ff (gg x) == x);
   gg_ff : x:_ -> squash (gg (ff x) == x);
@@ -40,8 +40,8 @@ let bij_unit_natlt1 : bijection unit (natlt 1) = {
 }
 
 (* Move values across bijections. *)
-let ( |~> ) (#a #b : Type) (x : a) (bij : a =~ b) : b = bij.ff x
-let ( <~| ) (#a #b : Type) (x : b) (bij : a =~ b) : a = bij.gg x
+let ( |~> ) (#a #b : Type) (x : a) (bij : a =~ b) : GTot b = bij.ff x
+let ( <~| ) (#a #b : Type) (x : b) (bij : a =~ b) : GTot a = bij.gg x
 
 val galois (#a #b : _) (d : a =~ b) (x:a) (y:b)
   : Lemma (d.ff x == y <==> x == d.gg y)
@@ -53,7 +53,6 @@ val galois_forall (#a #b : _) (d : a =~ b)
           [SMTPat (has_type d (a =~ b))] // OK? Useful?
 #pop-options
 
-inline_for_extraction noextract
 let bij_self (a:Type) : (a =~ a) =
 {
   ff = id;
@@ -63,7 +62,6 @@ let bij_self (a:Type) : (a =~ a) =
 }
 
 unfold
-inline_for_extraction noextract
 let bij_sym (#a #b : Type) (d : a =~ b) : (b =~ a) =
 {
   ff = d.gg;
@@ -72,16 +70,14 @@ let bij_sym (#a #b : Type) (d : a =~ b) : (b =~ a) =
   gg_ff = d.ff_gg;
 }
 
-inline_for_extraction noextract
 let bij_comp (#a #b #c : Type) (ab : a =~ b) (bc : b =~ c) : (a =~ c) =
 {
-  ff = bc.ff `o` ab.ff;
-  gg = ab.gg `o` bc.gg;
+  ff = bc.ff `oo` ab.ff;
+  gg = ab.gg `oo` bc.gg;
   ff_gg = (fun x -> ab.ff_gg (bc.gg x); bc.ff_gg x);
   gg_ff = (fun x -> bc.gg_ff (ab.ff x); ab.gg_ff x);
 }
 
-inline_for_extraction noextract
 let bij_prod (#a #b #c #d : Type) (ab : a =~ b) (cd : c =~ d) : (a & c =~ b & d) =
 {
   ff = (fun (x, y) -> (ab.ff x, cd.ff y));
@@ -94,7 +90,6 @@ let bij_prod (#a #b #c #d : Type) (ab : a =~ b) (cd : c =~ d) : (a & c =~ b & d)
     ab.gg_ff x1; cd.gg_ff x2);
 }
 
-inline_for_extraction noextract
 let bij_flip (#a #b : Type) : (a & b =~ b & a) =
 {
   ff = (fun (x, y) -> (y, x));
@@ -105,11 +100,13 @@ let bij_flip (#a #b : Type) : (a & b =~ b & a) =
 
 (* weird typing errors without hoisting. *)
 unfold
+inline_for_extraction noextract
 let prod_ff (n1 n2 : nat) : natlt n1 & natlt n2 -> natlt (n1 * n2) =
   // fun (x, y) -> (x * n2 + y)
   fun xy -> (xy._1 * n2 + xy._2)
 
 unfold
+inline_for_extraction noextract
 let prod_gg (n1 n2 : nat) : natlt (n1 * n2) -> natlt n1 & natlt n2 =
   fun i -> (i / n2, i % n2)
 
@@ -134,7 +131,6 @@ val bij_cardinal (n1 n2 : nat)
 the body of ff. It seems to try to try to define a bijection into SZ.t,
 regardless of the annotation on the letbinding and the annotation on the
 binder for m in gg. *)
-inline_for_extraction noextract
 let fin_size_t_bij (n:nat{SZ.fits n}) : (natlt n =~ szlt n) =
   {
     ff = (fun (i : natlt n) -> SZ.uint_to_t i <: szlt n);
@@ -157,7 +153,6 @@ let sz_prod_gg (n1:SZ.t) (n2:SZ.t{SZ.fits (SZ.v n1 * SZ.v n2)})
   = fun i -> (i /^ n2, i %^ n2)
 
 unfold
-inline_for_extraction noextract
 let bij_sz_prod (n1:SZ.t) (n2:SZ.t{SZ.fits (SZ.v n1 * SZ.v n2)})
   : (szlt (SZ.v n1) & szlt (SZ.v n2) =~ szlt (SZ.v n1 * SZ.v n2))
   = {
@@ -167,7 +162,6 @@ let bij_sz_prod (n1:SZ.t) (n2:SZ.t{SZ.fits (SZ.v n1 * SZ.v n2)})
     gg_ff = ez;
   }
 
-inline_for_extraction noextract
 let bij_either (#a #b #c #d : Type)
   (ab : a =~ b) (cd : c =~ d) : (either a c =~ either b d) =
 {
@@ -210,7 +204,6 @@ let bij_sz_sum_gg (n1 : sz) (n2 : sz{SZ.fits (SZ.v n1 + SZ.v n2)})
     then Inl i
     else Inr (i -^ n1)
 
-inline_for_extraction noextract
 let bij_sz_sum (n1 : sz) (n2 : sz{SZ.fits (SZ.v n1 + SZ.v n2)})
   : (either (szlt n1) (szlt n2) =~ szlt (n1 + n2)) =
 {
@@ -235,11 +228,11 @@ let inj_bij' (#a #b : Type) (bij : a =~ b) : (b @~> a) =
   }
 
 let bij_inj (#a #b : Type) (inj : a @~> b)
-  : GTot (a =~ image_of inj)
-= let ff : a -> image_of inj = (fun x -> inj.f x) in
+  : (a =~ image_of inj)
+= let ff : a -> GTot (image_of inj) = (fun x -> inj.f x) in
   {
     ff = ff;
-    gg = Kuiper.GhostPull.ghost_pull (FStar.Functions.inverse_of_bij ff);
+    gg = FStar.Functions.inverse_of_bij ff;
     ff_gg = ez;
     gg_ff = ez;
   }
@@ -250,7 +243,7 @@ let bij_inj' (#a #b : Type) (inj : a @~> b)
           (ensures fun _ -> True)
 = {
   ff = inj.f;
-  gg = Kuiper.GhostPull.ghost_pull (FStar.Functions.inverse_of_bij inj.f);
+  gg = FStar.Functions.inverse_of_bij inj.f;
   ff_gg = ez;
   gg_ff = ez;
 }
@@ -278,6 +271,23 @@ let bij_is_surj' (#a #b : Type) (bij : a =~ b) :
   assert (forall x. bij.gg (bij.ff x) == x);
    ()
 
+(* Computationally relevant bijections *)
+inline_for_extraction noextract
+noeq type cbij (a b: Type) = {
+  bij: (a =~ b);
+  cff: cff: (a -> b) { forall x. cff x == bij.ff x };
+  cgg: cgg: (b -> a) { forall x. cgg x == bij.gg x };
+}
+inline_for_extraction
+let (==~) = cbij
+
+inline_for_extraction noextract
+let fin_size_t_cbij (n:nat{SZ.fits n}) : (natlt n ==~ szlt n) =
+  {
+    bij = fin_size_t_bij n;
+    cff = (fun (i : natlt n) -> SZ.uint_to_t i <: szlt n);
+    cgg = (fun (m : szlt n)  -> SZ.v m <: natlt n);
+  }
 
 (* A type of "natural" bijections that we solve via
 typeclass resolution. *)

--- a/src/lib/kuiper/Kuiper.Enumerable.fst
+++ b/src/lib/kuiper/Kuiper.Enumerable.fst
@@ -28,7 +28,7 @@ let bijection_implies_equal_cardinal
     __bij_cardinal (cardinal a #_) (cardinal b #_) bij'
 
 let no_inj_to_smaller_nat (n1 n2 : nat{n2 < n1})
-  (f : natlt n1 -> natlt n2)
+  (f : natlt n1 -> GTot (natlt n2))
   : Lemma (exists (x y : natlt n1). x <> y /\ f x == f y)
   = admit()
 
@@ -50,7 +50,7 @@ let injection_equal_cardinal_implies_bijection
   = let contra (y : b)
       : Lemma (requires ~(exists (x : a). inj.f x == y))
               (ensures False)
-      = let f' : a -> (y':b{y' =!= y}) = (fun x -> inj.f x) in
+      = let f' : a -> GTot (y':b{y' =!= y}) = (fun x -> inj.f x) in
         assert (Functions.is_inj f');
         let inj' : injection a (y':b{y' =!= y}) = { f = f'; is_inj = ez } in
         // injection_implies_lte_cardinal a (y':b{y' =!= y}) inj';

--- a/src/lib/kuiper/Kuiper.Functions.fst
+++ b/src/lib/kuiper/Kuiper.Functions.fst
@@ -3,12 +3,12 @@ module Kuiper.Functions
 include FStar.Functions
 
 val __pigeon (n1:nat) (n2:nat{n2 < n1})
-  (f : natlt n1 -> natlt n2)
+  (f : natlt n1 -> GTot (natlt n2))
   : Lemma (requires is_inj f) (ensures False)
 let __pigeon n1 n2 f = admit()
 
 let pigeon (n1:nat) (n2:nat{n2 < n1})
-  (f : natlt n1 -> natlt n2)
+  (f : natlt n1 -> GTot (natlt n2))
   : Lemma (~ (is_inj f))
   =
   Classical.forall_intro (Classical.move_requires (__pigeon n1 n2))

--- a/src/lib/kuiper/Kuiper.Functions.fsti
+++ b/src/lib/kuiper/Kuiper.Functions.fsti
@@ -26,10 +26,10 @@ let is_comm_semigroup (#a:Type) (e:a) (f : a -> a -> a) : prop =
 let is_monoid (#a:Type) (e : a) (f : a -> a -> a) : prop =
   is_associative f /\ is_neutral_for e f
 
-let no_overlap (f1 : 'a -> 'c) (f2 : 'b -> 'c) : prop =
+let no_overlap (f1 : 'a -> GTot 'c) (f2 : 'b -> GTot 'c) : prop =
   forall (x1 : 'a) (x2 : 'b). f1 x1 =!= f2 x2
 
-let merge_either (f1 : 'a -> 'c) (f2 : 'b -> 'c) (x : either 'a 'b) : 'c =
+let merge_either (f1 : 'a -> GTot 'c) (f2 : 'b -> GTot 'c) (x : either 'a 'b) : GTot 'c =
   match x with
   | Inl x1 -> f1 x1
   | Inr x2 -> f2 x2
@@ -38,5 +38,5 @@ let left  (e : either 'a 'b{Inl? e}) : 'a = let Inl x = e in x
 let right (e : either 'a 'b{Inr? e}) : 'b = let Inr x = e in x
 
 val pigeon (n1:nat) (n2:nat{n2 < n1})
-  (f : natlt n1 -> natlt n2)
+  (f : natlt n1 -> GTot (natlt n2))
   : Lemma (~ (is_inj f))

--- a/src/lib/kuiper/Kuiper.GhostPull.fsti
+++ b/src/lib/kuiper/Kuiper.GhostPull.fsti
@@ -1,4 +1,0 @@
-module Kuiper.GhostPull
-
-(* An axiom. Used to be in the F* library. *)
-val ghost_pull (#a #b:Type) (f: a -> GTot b) : GTot (g:(a -> b) { forall x. f x == g x })

--- a/src/lib/kuiper/Kuiper.Injection.fsti
+++ b/src/lib/kuiper/Kuiper.Injection.fsti
@@ -2,7 +2,6 @@ module Kuiper.Injection
 
 #lang-pulse
 open Kuiper.Common
-open Kuiper.GhostPull
 open Kuiper.SizeT
 
 open FStar.Functions
@@ -12,15 +11,15 @@ open FStar.SizeT { (/^), (%^), (+^), (-^), ( *^ )  }
 (* A theory of injections. *)
 
 noeq
-inline_for_extraction noextract (* IMPORTANT! *)
+[@@erasable]
 type injection (a b : Type) = {
-  f : a -> b;
+  f : a -> GTot b;
 
   is_inj : x:_ -> y:_ -> squash (f x == f y ==> x == y);
 }
 
 // Terrible symbol, but F* is limited in operator support.
-inline_for_extraction
+[@@erasable]
 let ( @~> ) a b = injection a b
 
 let mk_injection
@@ -30,15 +29,8 @@ let mk_injection
   : (a @~> b) =
   Mkinjection f is_inj
 
-inline_for_extraction noextract
-let inj_id #a : (a @~> a) = {
-  f = id;
-  is_inj = ez;
-}
-
 (* Apply an injection to a value. *)
-inline_for_extraction
-let ( |~> ) (#a #b : Type) (x : a) (i : a `injection` b) : b = i.f x
+let ( |~> ) (#a #b : Type) (x : a) (i : a `injection` b) : GTot b = i.f x
 
 val lem_pat (#a #b : _) (d : a @~> b) (x y : a)
   : Lemma (d.f x == d.f y ==> x == y)
@@ -58,7 +50,7 @@ let inverse_f (#a #b : Type) (i : a @~> b) (y : image_of i) : GTot a =
 
 (* An injection can be inverted, but this requires choice. *)
 let inverse (#a #b : Type) (i : a @~> b) : Ghost.erased (image_of i @~> a) = {
-  f = ghost_pull (inverse_f i);
+  f = inverse_f i;
 
   is_inj = ez;
 }
@@ -66,38 +58,71 @@ let inverse (#a #b : Type) (i : a @~> b) : Ghost.erased (image_of i @~> a) = {
 let ( <~| ) (#a #b : Type) (y : b) (i : a `injection` b{in_image i.f y}) : GTot a =
   y |~> inverse i
 
-inline_for_extraction noextract
 let inj_prod (i1 : 'a @~> 'c) (i2 : 'b @~> 'd) : ('a & 'b @~> 'c & 'd) =
 {
   f = (fun (a,b) -> (i1.f a, i2.f b));
   is_inj = ez;
 }
 
-inline_for_extraction noextract
 let inj_either (i1 : 'a @~> 'c) (i2 : 'b @~> 'd) : (either 'a 'b @~> either 'c 'd) =
 {
   f = (function | Inl a -> Inl (i1.f a) | Inr b -> Inr (i2.f b));
   is_inj = ez;
 }
 
-inline_for_extraction noextract
 let inj_comp (i1 : 'a @~> 'b) (i2 : 'b @~> 'c) : ('a @~> 'c) =
 {
-  f = i2.f `o` i1.f;
+  f = i2.f `oo` i1.f;
   is_inj = ez;
 }
 
-unfold
+(* Computationally relevant injections *)
+inline_for_extraction noextract
+noeq type cinj (a b: Type) = {
+  inj: (a @~> b);
+  cf: cf: (a -> b) { forall x. cf x == inj.f x };
+}
+inline_for_extraction
+let (@~>>) = cinj
+
+inline_for_extraction noextract
+let cinj_comp #a #b #c (ab: a @~>> b) (bc: b @~>> c) : (a @~>> c) =
+{
+  inj = ab.inj `inj_comp` bc.inj;
+  cf = bc.cf `o` ab.cf;
+}
+
+inline_for_extraction noextract
+let cinj_either (i1 : 'a @~>> 'c) (i2 : 'b @~>> 'd) : (either 'a 'b @~>> either 'c 'd) =
+{
+  inj = i1.inj `inj_either` i2.inj;
+  cf = (function | Inl a -> Inl (i1.cf a) | Inr b -> Inr (i2.cf b));
+}
+
+unfold inline_for_extraction noextract
+let mk_cinj #a #b (f: a -> b) (#[Tactics.V2.easy_fill ()] is_inj: _) : (a @~>> b) =
+{
+  inj = { f; is_inj };
+  cf = f;
+}
+
+inline_for_extraction noextract
+let cinj_id #a : (a @~>> a) = mk_cinj id
+
+let inj_id #a : (a @~> a) = cinj_id.inj
+
+unfold inline_for_extraction noextract
 let inj_nat_sum_f (n1 n2 : nat) : either (natlt n1) (natlt n2) -> natlt (n1 + n2) =
   function
     | Inl i -> i
     | Inr j -> n1 + j
 
+inline_for_extraction noextract
+let cinj_nat_sum (n1 n2 : nat) : (either (natlt n1) (natlt n2) @~>> natlt (n1 + n2)) =
+  mk_cinj (inj_nat_sum_f n1 n2)
+
 let inj_nat_sum (n1 n2 : nat) : (either (natlt n1) (natlt n2) @~> natlt (n1 + n2)) =
-{
-  f = inj_nat_sum_f n1 n2;
-  is_inj = ez; (* does not work if inj_nat_sum_f is inlined. *)
-}
+  (cinj_nat_sum n1 n2).inj
 
 inline_for_extraction noextract
 let inj_sz_sum_f
@@ -111,14 +136,18 @@ let inj_sz_sum_f
 
 // n2 is not really needed
 inline_for_extraction noextract
+let cinj_sz_sum
+  (n1 n2 : Ghost.erased nat{SZ.fits (n1+n2)})
+  (s1 : SZ.t{SZ.v s1 == Ghost.reveal n1})
+: (either (szlt n1) (szlt n2) @~>> szlt (n1 + n2)) =
+  mk_cinj (inj_sz_sum_f n1 n2 s1)
+
+// n2 is not really needed
 let inj_sz_sum
   (n1 n2 : Ghost.erased nat{SZ.fits (n1+n2)})
   (s1 : SZ.t{SZ.v s1 == Ghost.reveal n1})
 : (either (szlt n1) (szlt n2) @~> szlt (n1 + n2)) =
-{
-  f = inj_sz_sum_f n1 n2 s1;
-  is_inj = ez; (* does not work if inj_sz_sum_f is inlined. *)
-}
+  (cinj_sz_sum n1 n2 s1).inj
 
 val inj_cardinal (n1 n2 : nat)
   : Lemma (requires exists (b : natlt n1 @~> natlt n2). True)

--- a/src/lib/spec/Kuiper.GhostMap.fst
+++ b/src/lib/spec/Kuiper.GhostMap.fst
@@ -8,8 +8,8 @@ module F = FStar.FunctionalExtensionality
 let ghost_map_acc
   (#mt:Type) (#it:Type) (#et:Type)
   (gm : is_ghost_map mt it et)
-  (i : it) (m : erased mt)
-  : Lemma (hide (gm.bij.ff m i) == gm.acc m i)
+  (i : it) (m : mt)
+  : Lemma (gm.bij.ff m i == gm.acc m i)
           [SMTPatOr [[SMTPat (gm.bij.ff m i)];
                      [SMTPat (gm.acc m i)]]]
   = gm.l1 i m
@@ -17,7 +17,7 @@ let ghost_map_acc
 let ghost_map_upd
   (#mt:Type) (#it:Type) (#et:Type)
   (gm : is_ghost_map mt it et)
-  (i : it) (m : erased mt) (e : et)
+  (i : it) (m : mt) (e : et)
   : Lemma (gm.bij.ff (gm.upd m i e) == oplus (gm.bij.ff m) i e)
           [SMTPatOr [[SMTPat (gm.bij.ff (gm.upd m i e))];
                      [SMTPat (oplus (gm.bij.ff m) i e)]]]
@@ -29,15 +29,12 @@ let prod_ff
   (#mb #ib : Type)
   (gm1 : is_ghost_map ma ia et)
   (gm2 : is_ghost_map mb ib et)
-  : erased (ma & mb) -> (either ia ib ^->> et)
+  : (ma & mb) -> (either ia ib ^->> et)
   = fun m ->
       F.on_g _ <| fun (i : either ia ib) ->
       match i with
       | Inl i1 -> gm1.bij.ff (fst m) i1
       | Inr i2 -> gm2.bij.ff (snd m) i2
-
-let oo #a #b #c (g : b ^->> c) (f : a -> b) : (a ^->> c)
-  = F.on_g _ <| fun x -> g (f x)
 
 let prod_gg
   (#et : Type)
@@ -45,12 +42,10 @@ let prod_gg
   (#mb #ib : Type)
   (gm1 : is_ghost_map ma ia et)
   (gm2 : is_ghost_map mb ib et)
-  : GTot ((either ia ib ^->> et) -> erased (ma & mb))
-  = let gg1 = gm1.bij.gg in
-    let gg2 = gm2.bij.gg in
-    fun (gm : (either ia ib) ^->> et) ->
-    (reveal <| gg1 (F.on_g _ <| gm `oo` Inl),
-     reveal <| gg2 (F.on_g _ <| gm `oo` Inr))
+  : ((either ia ib ^->> et) -> GTot (ma & mb))
+  = fun (gm : (either ia ib) ^->> et) ->
+    (gm1.bij.gg (F.on_g _ <| gm `oo` Inl),
+     gm2.bij.gg (F.on_g _ <| gm `oo` Inr))
 
 let prod_ff_gg
   (#et : Type)
@@ -68,7 +63,7 @@ let prod_gg_ff
   (#mb #ib : Type)
   (gm1 : is_ghost_map ma ia et)
   (gm2 : is_ghost_map mb ib et)
-  (m : erased (ma & mb))
+  (m : ma & mb)
   : squash (prod_gg gm1 gm2 (prod_ff gm1 gm2 m) == m)
   = let m1, m2 = m in
     let m1', m2' = prod_gg gm1 gm2 (prod_ff gm1 gm2 m) in
@@ -86,9 +81,9 @@ let prod_bij
   (#mb #ib : Type)
   (gm1 : is_ghost_map ma ia et)
   (gm2 : is_ghost_map mb ib et)
-  : GTot (bijection (erased (ma & mb)) (either ia ib ^->> et))
+  : GTot (bijection ((ma & mb)) (either ia ib ^->> et))
 = Mkbijection
-    #(erased (ma & mb))
+    #((ma & mb))
     #(either ia ib ^->> et) // Some terrible inference here, forced me to give these parameters explicitly
     (prod_ff gm1 gm2)
     (prod_gg gm1 gm2)

--- a/src/lib/spec/Kuiper.GhostMap.fsti
+++ b/src/lib/spec/Kuiper.GhostMap.fsti
@@ -21,15 +21,15 @@ let oplus (#a #b : Type) (f : a -> GTot b) (x : a) (y : b) : (a ^->> b) =
 [@@erasable]
 class is_ghost_map (mt : Type) (it : Type) (et : Type) = {
   [@@@no_method]
-  bij : erased mt =~ (it ^->> et);
+  bij : mt =~ (it ^->> et);
   [@@@no_method]
-  acc : mt -> it -> erased et;
+  acc : mt -> it -> GTot et;
   [@@@no_method]
-  upd : mt -> it -> et -> erased mt;
+  upd : mt -> it -> et -> GTot mt;
 
   [@@@no_method]
   l1 : (i:it -> m:mt ->
-         squash (hide (bij.ff m i) == acc m i));
+         squash (bij.ff m i == acc m i));
   [@@@no_method]
   l2 : (i:it -> m:mt -> e:et ->
          squash (bij.ff (upd m i e) `F.feq_g` oplus (bij.ff m) i e));
@@ -38,15 +38,15 @@ class is_ghost_map (mt : Type) (it : Type) (et : Type) = {
 val ghost_map_acc
   (#mt:Type) (#it:Type) (#et:Type)
   (gm : is_ghost_map mt it et)
-  (i : it) (m : erased mt)
-  : Lemma (hide (gm.bij.ff m i) == gm.acc m i)
+  (i : it) (m : mt)
+  : Lemma (gm.bij.ff m i == gm.acc m i)
           [SMTPatOr [[SMTPat (gm.bij.ff m i)];
                      [SMTPat (gm.acc m i)]]]
 
 val ghost_map_upd
   (#mt:Type) (#it:Type) (#et:Type)
   (gm : is_ghost_map mt it et)
-  (i : it) (m : erased mt) (e : et)
+  (i : it) (m : mt) (e : et)
   : Lemma (gm.bij.ff (gm.upd m i e) == oplus (gm.bij.ff m) i e)
           [SMTPatOr [[SMTPat (gm.bij.ff (gm.upd m i e))];
                      [SMTPat (oplus (gm.bij.ff m) i e)]]]
@@ -75,14 +75,14 @@ val lemma_is_ghost_map_prod_acc
 open FStar.Ghost
 open FStar.Seq
 
-let lseq_to_ghost_map (#et:Type) (#len:nat) : erased (lseq et len) -> (natlt len ^->> et) =
+let lseq_to_ghost_map (#et:Type) (#len:nat) : (lseq et len) -> GTot (natlt len ^->> et) =
   fun v -> F.on_g _ fun (i:natlt len) -> Seq.index (reveal v) i <: et
 
-let lseq_from_ghost_map (#et:Type) (#len:nat) : (natlt len ^->> et) -> erased (lseq et len) =
+let lseq_from_ghost_map (#et:Type) (#len:nat) : (natlt len ^->> et) -> GTot (lseq et len) =
   fun f -> hide (Seq.init_ghost len f)
 
 noextract
-let bij_lseq_ghost_map (et:Type) (len:nat) : bijection (erased (lseq et len)) (natlt len ^->> et) = {
+let bij_lseq_ghost_map (et:Type) (len:nat) : bijection (lseq et len) (natlt len ^->> et) = {
   ff = lseq_to_ghost_map;
   gg = lseq_from_ghost_map;
   ff_gg = (fun f ->
@@ -90,8 +90,7 @@ let bij_lseq_ghost_map (et:Type) (len:nat) : bijection (erased (lseq et len)) (n
     ()
   );
   (* We need to state this, otherwise we get a coercion that messes things up. *)
-  gg_ff = (fun (es : erased (lseq et len)) ->
-    (* ARGH! without stating erased above, we seem to implicly get a reveal coercion that messes things up. *)
+  gg_ff = (fun es ->
     assert (Seq.equal (lseq_from_ghost_map (lseq_to_ghost_map es)) es);
     ()
   );
@@ -108,13 +107,7 @@ instance lseq_is_ghost_map (et:Type) (len:nat) : is_ghost_map (lseq et len) (nat
 
 instance ghost_map_is_ghost_map #a #b : is_ghost_map (a ^->> b) a b =
   {
-    bij =
-      (Mkbijection #(erased (a ^->> b)) #(a ^->> b)
-        reveal
-        hide
-        ez
-        ez
-      );
+    bij = bij_self (a ^->> b);
     acc = (fun m i -> m i);
     upd = (fun m i e -> oplus m i e);
     l1 = ez;

--- a/src/lib/views/Kuiper.IView.fsti
+++ b/src/lib/views/Kuiper.IView.fsti
@@ -95,7 +95,7 @@ type ciview_schema (asch : aiview_schema) = {
 inline_for_extraction noextract
 let raw_ciview_schema (len : erased nat{SZ.fits len}) : ciview_schema (raw_aiview_schema len) = {
   cit = szlt len;
-  bij = natural;
+  bij = fin_size_t_bij _;
 }
 
 (* A step in a concrete indexing view. *)
@@ -110,7 +110,7 @@ class ciview_step
 {
   (* Concrete index translation *)
   [@@@no_method]
-  cimap : csch1.cit @~> csch2.cit;
+  cimap : csch1.cit @~>> csch2.cit;
 
   (* The mappings are compatible. I.e. the following diagram commutes:
 
@@ -125,7 +125,7 @@ class ciview_step
   [@@@no_method]
   compat :
     ai : asch1.ait ->
-      squash (cimap.f (csch1.bij.ff ai) == csch2.bij.ff (step.imap.f ai));
+      squash (cimap.cf (csch1.bij.ff ai) == csch2.bij.ff (step.imap.f ai));
 }
 
 (* What it means for an indexing view to be concretizable, i.e. executable. *)
@@ -147,7 +147,7 @@ instance concrete_raw_view (#len : nat{SZ.fits len}) : ciview (raw_view #len) = 
   clen = SZ.uint_to_t len; // weird
   sch  = raw_ciview_schema len;
   step = {
-    cimap  = inj_id;
+    cimap  = cinj_id;
     compat = ez;
   };
 }
@@ -248,7 +248,7 @@ let compose_cstep
   (c2 : ciview_step csch2 csch3 step23)
   : ciview_step csch1 csch3 (compose_astep step12 step23) =
 {
-  cimap = c1.cimap `inj_comp` c2.cimap;
+  cimap = c1.cimap `cinj_comp` c2.cimap;
 
   compat = (fun ai ->
     c1.compat ai;

--- a/src/lib/views/Kuiper.View.Concat.fsti
+++ b/src/lib/views/Kuiper.View.Concat.fsti
@@ -59,8 +59,8 @@ instance cview_concat
     cimap = (
       assert (SZ.v cw1.clen == vw1.iview.len);
       assert (SZ.v cw2.clen == vw2.iview.len);
-      inj_either cw1.step.cimap cw2.step.cimap
-              `inj_comp` inj_sz_sum (len vw1) (len vw2) cw1.clen
+      cinj_either cw1.step.cimap cw2.step.cimap
+              `cinj_comp` cinj_sz_sum (len vw1) (len vw2) cw1.clen
     );
 
 

--- a/src/lib/views/Kuiper.View.fst
+++ b/src/lib/views/Kuiper.View.fst
@@ -20,20 +20,19 @@ let to_from (#a:Type) (#st:Type)
     (* funny, mentioning the term above (= from_seq vw s) makes the proof work. *)
     let aux (i : natlt (len vw))
       : Lemma (to_seq vw (from_seq vw s) @! i == s @! i) =
+      let g = from_seq_aux vw s in
       calc (==) {
         to_seq vw (from_seq vw s) @! i;
         == {}
-        Seq.init_ghost (len vw) (fun (j : natlt (len vw)) -> reveal (vw.igm.acc (from_seq vw s) (it_of_nat vw j))) @! i;
+        Seq.init_ghost (len vw) (fun (j : natlt (len vw)) -> (vw.igm.acc (from_seq vw s) (it_of_nat vw j))) @! i;
         == {}
-        reveal (vw.igm.acc (from_seq vw s) (it_of_nat vw i));
+        (vw.igm.acc (from_seq vw s) (it_of_nat vw i));
         == {}
         vw.igm.bij.ff (from_seq vw s) (it_of_nat vw i);
         == {}
-        vw.igm.bij.ff (vw.igm.bij.gg (F.on_g vw.iview.sch.ait <| fun i -> s @! it_to_nat vw i))
-          (it_of_nat vw i);
-        == {}
-        (F.on_g vw.iview.sch.ait <| fun i -> s @! it_to_nat vw i)
-          (it_of_nat vw i);
+        vw.igm.bij.ff (vw.igm.bij.gg g) (it_of_nat vw i);
+        == { vw.igm.bij.ff_gg g }
+        g (it_of_nat vw i);
         == {}
         s @! it_to_nat vw (it_of_nat vw i);
         == { assert_norm (it_to_nat vw (it_of_nat vw i) == i) }
@@ -55,14 +54,15 @@ let from_to (#a:Type) (#st:Type)
   let rf = vw.igm.bij.ff rhs in
   let aux (i : vw.iview.sch.ait)
     : Lemma (lf i == rf i) =
+    let g = from_seq_aux vw (to_seq vw v) in
     calc (==) {
       lf i;
       == {}
       vw.igm.bij.ff (from_seq vw (to_seq vw v)) i;
       == {}
-      vw.igm.bij.ff (vw.igm.bij.gg (F.on_g vw.iview.sch.ait <| fun i -> to_seq vw v @! it_to_nat vw i)) i;
-      == {}
-      (F.on_g vw.iview.sch.ait <| fun i -> to_seq vw v @! it_to_nat vw i) i;
+      vw.igm.bij.ff (vw.igm.bij.gg g) i;
+      == { vw.igm.bij.ff_gg g }
+      g i;
       == {}
       to_seq vw v @! it_to_nat vw i;
       == {}

--- a/src/lib/views/Kuiper.View.fsti
+++ b/src/lib/views/Kuiper.View.fsti
@@ -107,7 +107,7 @@ let igm_review (#mt #it #et : Type) (igm : is_ghost_map mt it et)
 {
   acc = (fun (v : mt') (i : it) -> igm.acc (bij.gg v) i);
   upd = (fun (v : mt') (i : it) (x : et) -> bij.ff (igm.upd (bij.gg v) i x));
-  bij = bij_erase (bij_sym bij) `bij_comp` igm.bij;
+  bij = bij_sym bij `bij_comp` igm.bij;
   l1 = ez;
   l2 = ez;
 }
@@ -181,12 +181,18 @@ let to_seq
   = Seq.init_ghost (len vw) fun (i : natlt (len vw)) ->
       reveal (vw.igm.acc v (it_of_nat vw i))
 
+let from_seq_aux
+  (#a:Type) (#st:Type)
+  (vw : aview a st)
+  (s : lseq a (len vw))
+  = F.on_g vw.iview.sch.ait fun i -> s @! it_to_nat vw i
+
 let from_seq
   (#a:Type) (#st:Type)
   (vw : aview a st)
   (s : lseq a (len vw))
   : GTot st
-  = vw.igm.bij.gg (F.on_g vw.iview.sch.ait <| fun i -> s @! it_to_nat vw i)
+  = vw.igm.bij.gg (from_seq_aux vw s)
 
 val to_from (#a:Type) (#st:Type)
   (vw : aview a st { is_full_view vw })


### PR DESCRIPTION
This PR makes the bijections and injections ghost, and for the relatively few cases where we need to execute them adds computationally relevant `==~` and `@~>>` types like this:
```fstar
(* Computationally relevant injections *)
inline_for_extraction noextract
noeq type cinj (a b: Type) = {
  inj: (a @~> b);
  cf: cf: (a -> b) { forall x. cf x == inj.f x };
}
```

This also easily generalizes to stateful maps, e.g. if the injection function is implemented using a look-up table.  (Although I really don't know if this would be useful.)

Some things become a bit easier, since e.g. ghost maps already had an erased in there and now this is implicit.

Surprisingly, this PR only increases the code size by six lines.