### PR TITLE
Enable and improve list-admits for missing fst files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,11 @@ lint: lint-c lint-fstar
 
 .PHONY: list-admits
 list-admits:
-	-git grep -w 'assume_\|assume\|admit\|magic' src
-	#-find src -name '*.fsti' -printf '%f\n' | while read fsti; do fst=$${fsti%i}; if ! find src -name "$$fst" | grep -q "$$fst" ; then echo "Module $$fsti is assumed"; fi; done
+	(git grep --color -w 'assume_\|assume\|admit\|magic' src; \
+	find src -name \*.fsti | sort \
+		| sed 's/i$$//;/Kuiper.Kernel.Base.fst/d;/Kuiper.\(Array.Vectorized\|AtomicOps\).fst/d;/Kuiper.TensorCore.Base.fst/d;/Kuiper.\(Float[0-9]\+\|SizeT\).fst/d' \
+		| while read fn; do if [[ ! -f $$fn ]]; then echo Missing implementation file: $$fn; fi; done \
+	) | less -R
 
 .PHONY: wc
 wc:


### PR DESCRIPTION
This 1) enables the part of list-admits which checks for missing fst files and 2) filters out the intentional interface files.

The following files are missing as of now:
```
Missing implementation file: src/lib/data/Kuiper.Matrix.Common.fst
Missing implementation file: src/lib/Kuiper.fst
Missing implementation file: src/lib/kuiper/Kuiper.Array.fst
Missing implementation file: src/lib/kuiper/Kuiper.Assert.fst
Missing implementation file: src/lib/kuiper/Kuiper.Atomics.fst
Missing implementation file: src/lib/kuiper/Kuiper.Barrier.fst
Missing implementation file: src/lib/kuiper/Kuiper.Base.fst
Missing implementation file: src/lib/kuiper/Kuiper.Bijection.Tile.fst
Missing implementation file: src/lib/kuiper/Kuiper.Common.fst
Missing implementation file: src/lib/kuiper/Kuiper.Concrete.fst
Missing implementation file: src/lib/kuiper/Kuiper.Epoch.fst
Missing implementation file: src/lib/kuiper/Kuiper.IntAliases.fst
Missing implementation file: src/lib/kuiper/Kuiper.Kernel.Desc.fst
Missing implementation file: src/lib/kuiper/Kuiper.Len.fst
Missing implementation file: src/lib/kuiper/Kuiper.Monoid.fst
Missing implementation file: src/lib/kuiper/Kuiper.PtsTo.fst
Missing implementation file: src/lib/kuiper/Kuiper.Ref.fst
Missing implementation file: src/lib/kuiper/Kuiper.SHMem.fst
Missing implementation file: src/lib/kuiper/Kuiper.Sized.fst
Missing implementation file: src/lib/poly/gemm/Kuiper.Poly.GEMMGPU.Type.fst
Missing implementation file: src/lib/views/Kuiper.View.Concat.fst
Missing implementation file: src/lib/views/Kuiper.View.TwoTiles.fst
```

Many of these can be easily fixed by just renaming the fsti to fst.  I'll do that in a follow-up PR.