### PR TITLE
Fix magic in Approximates.

### DIFF
--- a/src/lib/kuiper/Kuiper.Approximates.fst
+++ b/src/lib/kuiper/Kuiper.Approximates.fst
@@ -5,11 +5,25 @@ open FStar.Real
 open Kuiper.Scalars
 module M = FStar.Math.Lemmas
 
-(* We assume these types approximate reals. We cannot really prove it
-without a model of floating point (in both devices). *)
-let real_like_f16 : real_like f16 = magic ()
-let real_like_f32 : real_like f32 = magic ()
-let real_like_f64 : real_like f64 = magic ()
+// Every scalar admits the trivial approximation.
+// Note: we don't expose the approximates relation in the interface.
+let trivial_real_like a {| scalar a |} : real_like a = {
+  to_real = (fun _ -> 0.0R);
+  approximates = (fun _ _ -> True);
+  to_real_ok = (fun _ -> ());
+  a0 = ();
+  a1 = ();
+  a_add = (fun _ _ _ _ -> ());
+  a_mul = (fun _ _ _ _ -> ());
+}
+
+(* We assume these types approximate reals. We cannot prove it because we don't
+have an implementation for f16/etc., but if we did we could easily add a ghost
+real number to the type which would allow us to implement real_like with a
+strong approximation relation relating `x` only to `to_real x`. *)
+let real_like_f16 : real_like f16 = trivial_real_like _
+let real_like_f32 : real_like f32 = trivial_real_like _
+let real_like_f64 : real_like f64 = trivial_real_like _
 
 let mod_prod (a b : int) (k : pos) :
   Lemma (ensures (a % k) * (b % k) % k == (a * b) % k)
@@ -58,6 +72,6 @@ instance real_like_u8 : real_like u8 = {
 }
 
 (* The rest are essentially the same *)
-let real_like_u16 : real_like u16 = magic()
-let real_like_u32 : real_like u32 = magic()
-let real_like_u64 : real_like u64 = magic()
+let real_like_u16 : real_like u16 = trivial_real_like _
+let real_like_u32 : real_like u32 = trivial_real_like _
+let real_like_u64 : real_like u64 = trivial_real_like _


### PR DESCRIPTION
This fills the magic in the Kuiper.Approximates by giving a dummy implementation.

But I think the fact that we can do that just shows how lacking the approximates API is right now.  Not sure if it's worth merging this or just rewriting approximates entirely.