### PR TITLE
Prove `assume`s in Poly.GEMM.Copy.Vec

### DIFF
--- a/src/lib/kuiper/Kuiper.Divides.fst
+++ b/src/lib/kuiper/Kuiper.Divides.fst
@@ -127,3 +127,13 @@ let lemma_divides_mod_op (d: pos) (a: int) (b: pos)
   lemma_divides_product_r d b ((-1) * (a / b));
   lemma_divides_sum d a (((-1) * (a / b)) * b);
   ()
+
+let lemma_eucl_unique
+  (b: pos)
+  (q r q' r': nat)
+: Lemma (requires q * b + r == q' * b + r' /\
+    r < b /\
+    r' < b
+  )
+  (ensures q == q' /\ r == r')
+= ()

--- a/src/lib/kuiper/Kuiper.Divides.fst
+++ b/src/lib/kuiper/Kuiper.Divides.fst
@@ -47,6 +47,10 @@ let lemma_divides_exact (x:pos) (y:int)
 = lemma_divides_mod1 x y;
   Classical.move_requires (M.lemma_div_exact y) x
 
+let lemma_nat_divides_pos_divides (x: pos) (y: int)
+: Lemma (x /? y <==> x /?+ y)
+= ()
+
 let lemma_divides_le (x : nat) (y : pos)
   : Lemma (requires x /? y)
           (ensures x <= y)
@@ -114,3 +118,12 @@ let lemma_divides_chain (a b c : pos)
   : Lemma (requires a /? b /\ b /? c)
           (ensures a /? c)
   = ()
+
+let lemma_divides_mod_op (d: pos) (a: int) (b: pos)
+  : Lemma (requires d /? a /\
+            d /? b)
+          (ensures d /? (a % b))
+= assert ((a % b) == a + ((-1) * (a / b)) * b);
+  lemma_divides_product_r d b ((-1) * (a / b));
+  lemma_divides_sum d a (((-1) * (a / b)) * b);
+  ()

--- a/src/lib/kuiper/Kuiper.Divides.fsti
+++ b/src/lib/kuiper/Kuiper.Divides.fsti
@@ -70,3 +70,8 @@ val lemma_divides_product_r (d : pos) (a c : int)
 val lemma_divides_chain (a b c : pos)
   : Lemma (requires a /? b /\ b /? c)
           (ensures a /? c)
+
+val lemma_divides_mod_op (d: pos) (a: int) (b: pos)
+  : Lemma (requires d /? a /\
+            d /? b)
+          (ensures d /? (a % b))

--- a/src/lib/kuiper/Kuiper.Divides.fsti
+++ b/src/lib/kuiper/Kuiper.Divides.fsti
@@ -78,3 +78,12 @@ val lemma_divides_mod_op (d: pos) (a: int) (b: pos)
   : Lemma (requires d /? a /\
             d /? b)
           (ensures d /? (a % b))
+
+val lemma_eucl_unique
+  (b: pos)
+  (q r q' r': nat)
+: Lemma (requires q * b + r == q' * b + r' /\
+    r < b /\
+    r' < b
+  )
+  (ensures q == q' /\ r == r')

--- a/src/lib/kuiper/Kuiper.Divides.fsti
+++ b/src/lib/kuiper/Kuiper.Divides.fsti
@@ -29,6 +29,9 @@ val lemma_divides_exact (x:pos) (y:int)
   : Lemma (x /? y <==> x * (y/x) == y)
           [SMTPat (x /? y)]
 
+val lemma_nat_divides_pos_divides (x: pos) (y: int)
+: Lemma (x /? y <==> x /?+ y)
+
 val lemma_divides_le (x : nat) (y : pos)
   : Lemma (requires x /? y)
           (ensures x <= y)

--- a/src/lib/kuiper/Kuiper.ForEvery.fst
+++ b/src/lib/kuiper/Kuiper.ForEvery.fst
@@ -1161,8 +1161,6 @@ let bij_mirror_n (n:nat) : (natlt n =~ natlt n) =
   }
 
 
-#set-options "--debug SMTFail --split_queries always"
-
 ghost
 fn forevery_natlt_pop_shift
   (n: nat { n > 0 })

--- a/src/lib/kuiper/Kuiper.Math.Silly.fst
+++ b/src/lib/kuiper/Kuiper.Math.Silly.fst
@@ -43,3 +43,7 @@ let mod_prod (a b : int) (k : pos) :
   = M.lemma_mod_mul_distr_l a b k;
     M.lemma_mod_mul_distr_r (a % k) b k;
     ()
+
+let lemma_mul_pos_recip (a b: nat) :
+  Lemma (requires a * b > 0) (ensures a > 0 /\ b > 0)
+= ()

--- a/src/lib/kuiper/Kuiper.Math.Silly.fst
+++ b/src/lib/kuiper/Kuiper.Math.Silly.fst
@@ -47,3 +47,9 @@ let mod_prod (a b : int) (k : pos) :
 let lemma_mul_pos_recip (a b: nat) :
   Lemma (requires a * b > 0) (ensures a > 0 /\ b > 0)
 = ()
+
+let lemma_le_plus_lt (x y z w: int)
+: Lemma (requires (x + z <= w /\
+    y < z))
+    (ensures (x + y < w))
+= ()

--- a/src/lib/kuiper/Kuiper.Math.Silly.fsti
+++ b/src/lib/kuiper/Kuiper.Math.Silly.fsti
@@ -41,3 +41,8 @@ val mod_prod (a b : int) (k : pos) :
 
 val lemma_mul_pos_recip (a b: nat) :
   Lemma (requires a * b > 0) (ensures a > 0 /\ b > 0)
+
+val lemma_le_plus_lt (x y z w: int)
+: Lemma (requires (x + z <= w /\
+    y < z))
+    (ensures (x + y < w))

--- a/src/lib/kuiper/Kuiper.Math.Silly.fsti
+++ b/src/lib/kuiper/Kuiper.Math.Silly.fsti
@@ -38,3 +38,6 @@ val p4_assoc
 
 val mod_prod (a b : int) (k : pos) :
   Lemma (ensures (a % k) * (b % k) % k == (a * b) % k)
+
+val lemma_mul_pos_recip (a b: nat) :
+  Lemma (requires a * b > 0) (ensures a > 0 /\ b > 0)

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.Copy.Vec.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.Copy.Vec.fst
@@ -302,7 +302,10 @@ fn cp_matrix_vec
     let row = (!i +^ offset) /^ cols; assert (rewrites_to row ((!i +^ offset) /^ cols));
     let col = (!i +^ offset) %^ cols; assert (rewrites_to col ((!i +^ offset) %^ cols));
     assert pure (chunk et /?+ cols);
-    assume pure (chunk et /?+ col); // PROVE
+    assert pure (chunk et /?+ offset);
+    assert pure (chunk et /?+ !i);
+    lemma_divides_mod_op (chunk et) (!i +^ offset) cols;
+    assert pure (chunk et /?+ col);
     assert (pure (col + chunk et <= cols));
     assert pure (SZ.v offset == tid * chunk et);
     assert pure (row < rows);

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.Copy.Vec.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.Copy.Vec.fst
@@ -59,7 +59,7 @@ let coincide_on_tid_intro
     (i: natlt rows) ->
     (j: natlt cols) ->
     Lemma
-    (requires in_chunk (chunk et) rows cols nthr tid (i,j)) 
+    (requires in_chunk (chunk et) rows cols nthr tid (i,j))
     (ensures
         macc em1 i j == macc em2 i j
     )

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.Copy.Vec.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.Copy.Vec.fst
@@ -232,7 +232,7 @@ let em_fade
 
 let nop_tactic () : Tactics.Tac unit = ()
 
-#push-options "--z3rlimit 60 --fuel 0 --ifuel 1"
+#push-options "--z3rlimit 75 --fuel 0 --ifuel 1"
 inline_for_extraction noextract
 fn cp_matrix_vec
   (#et : Type0) {| scalar et, has_vec_cpy et |}
@@ -340,7 +340,9 @@ fn cp_matrix_vec
           own_strided_chunks dst em' nthr tid
     {
       with em'. unfold own_strided_chunks dst em' nthr tid;
-      assume pure (col + !k < cols);
+      with vk . assert (pts_to k vk);
+      Kuiper.Math.Silly.lemma_le_plus_lt col vk (chunk et) cols;
+      assert pure (col + !k < cols);
       let ecell : erased (natlt rows & natlt cols) = Mktuple2 #(natlt rows) #(natlt cols) row (col +^ !k);
       assume pure (in_chunk (chunk et) rows cols nthr tid ecell);
       forevery_remove'

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.Copy.Vec.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.Copy.Vec.fst
@@ -37,6 +37,50 @@ let in_chunk_no_overlap
   =
   ()
 
+let coincide_on_tid
+  (#et : Type0) {| sized et, hvc : has_vec_cpy et |}
+  (#rows #cols : nat)
+  (nthr : nat)
+  (tid : natlt nthr)
+  (em1 em2 : ematrix et rows cols)
+: Tot prop
+=
+      forall (i : natlt rows) (j : natlt cols).
+        in_chunk (chunk et) rows cols nthr tid (i,j) ==>
+        macc em1 i j == macc em2 i j
+
+let coincide_on_tid_intro
+  (#et : Type0) {| sized et, hvc : has_vec_cpy et |}
+  (#rows #cols : nat)
+  (nthr : nat)
+  (tid : natlt nthr)
+  (em1 em2 : ematrix et rows cols)
+  (prf:
+    (i: natlt rows) ->
+    (j: natlt cols) ->
+    Lemma
+    (requires in_chunk (chunk et) rows cols nthr tid (i,j)) 
+    (ensures
+        macc em1 i j == macc em2 i j
+    )
+  )
+: Lemma
+  (coincide_on_tid nthr tid em1 em2)
+= let prf'
+    (i: natlt rows)
+    (j: natlt cols)
+    : Lemma
+    (ensures (in_chunk (chunk et) rows cols nthr tid (i,j) ==>
+        macc em1 i j == macc em2 i j
+    ))
+  =
+    let flat_idx = i * cols + j <: nat in
+    let chunk_idx = flat_idx / chunk et in
+    if chunk_idx % nthr = tid
+    then prf i j
+  in
+  Classical.forall_intro_2 prf'
+
 ghost
 fn own_strided_chunks_rw
   (#et : Type0) {| sized et, hvc : has_vec_cpy et |}
@@ -47,10 +91,7 @@ fn own_strided_chunks_rw
   (tid : natlt nthr)
   (em1 em2 : ematrix et rows cols)
   requires
-    pure (
-      forall (i : natlt rows) (j : natlt cols).
-        in_chunk (chunk et) rows cols nthr tid (i,j) ==>
-        macc em1 i j == macc em2 i j)
+    pure (coincide_on_tid nthr tid em1 em2)
   requires
     own_strided_chunks m em1 nthr tid
   ensures
@@ -232,8 +273,9 @@ let em_fade
 
 let nop_tactic () : Tactics.Tac unit = ()
 
-#push-options "--z3rlimit 75 --fuel 0 --ifuel 1"
-let cp_matrix_vec_chunk_et_divides_col
+#push-options "--z3rlimit 16 --fuel 0 --ifuel 1"
+
+let cp_matrix_vec_chunk_et_divides_col'
   (et : Type0) {| scalar et, has_vec_cpy et |}
   (rows cols: pos)
   (nthr : pos)
@@ -242,7 +284,7 @@ let cp_matrix_vec_chunk_et_divides_col
   (sq: squash (
     chunk et /?+ cols /\
     tid < nthr /\
-    it <= (rows*cols) / (nthr * chunk et)
+    it < (rows*cols) / (nthr * chunk et)
   ))
 : Lemma
   (ensures (
@@ -271,7 +313,44 @@ let cp_matrix_vec_chunk_et_divides_col
     assert ((cols > 0));
     lemma_divides_mod_op (chunk et) (i + offset) cols;
     assert (chunk et /? col);
-    lemma_nat_divides_pos_divides (chunk et) col
+    lemma_nat_divides_pos_divides (chunk et) col;
+    assert (chunk et /?+ col)
+
+#pop-options
+
+let cp_matrix_vec_chunk_et_divides_col
+  (et : Type0) {| scalar et, has_vec_cpy et |}
+  (rows cols: pos)
+  (nthr : pos)
+  (tid: nat)
+  (it: nat)
+  (sq: squash (
+    chunk et /?+ cols /\
+    tid < nthr /\
+    it < (rows*cols) / (nthr * chunk et)
+  ))
+: Lemma
+  (ensures (
+    let i0 = it * nthr * chunk et in
+    let offset = tid * chunk et in
+    let row = (i0 + offset) / cols in
+    let col = (i0 + offset) % cols in
+    chunk et /?+ col /\
+    col + chunk et <= cols /\
+    offset == tid * chunk et /\
+    row < rows /\
+    col < cols - chunk et + 1
+  ))
+=
+    let i = it * nthr * chunk et in
+    let offset = tid * chunk et in
+    let row = (i + offset) / cols in
+    let col = (i + offset) % cols in
+    cp_matrix_vec_chunk_et_divides_col' et rows cols nthr tid it ();
+    assert ((col + chunk et <= cols));
+    assert (offset == tid * chunk et);
+    assert (row < rows);
+    assert (col < cols - chunk et + 1)
 
 let cp_matrix_vec_in_chunk
   (et : Type0) {| scalar et, has_vec_cpy et |}
@@ -283,14 +362,9 @@ let cp_matrix_vec_in_chunk
   (sq: squash (
     chunk et /?+ cols /\
     tid < nthr /\
-    it <= (rows*cols) / (nthr * chunk et) /\
+    it < (rows*cols) / (nthr * chunk et) /\
     k < chunk et /\ (
-    let i0 = it * nthr * chunk et in
-    let offset = tid * chunk et in
-    let row = (i0 + offset) / cols in
-    let col = (i0 + offset) % cols in
-    row < rows /\
-    col + k < cols
+    True
   )))
 : Lemma
   (ensures (
@@ -298,14 +372,18 @@ let cp_matrix_vec_in_chunk
     let offset = tid * chunk et in
     let row = (i0 + offset) / cols in
     let col = (i0 + offset) % cols in
+    row < rows /\
+    col + k < cols /\ (
     let ecell : (natlt rows & natlt cols) = Mktuple2 #(natlt rows) #(natlt cols) row (col + k) in
     in_chunk (chunk et) rows cols nthr tid ecell
-  ))
+  )))
 =
     let i = it * nthr * chunk et in
     let offset = tid * chunk et in
     let row = (i + offset) / cols in
     let col = (i + offset) % cols in
+    cp_matrix_vec_chunk_et_divides_col et rows cols nthr tid it ();
+    assert (chunk et /?+ col);
     let ecell : (natlt rows & natlt cols) = Mktuple2 #(natlt rows) #(natlt cols) row (col + k) in
     FStar.Math.Lemmas.euclidean_division_definition (i + offset) cols;
     assert ((i + offset == row * cols + col));
@@ -319,6 +397,125 @@ let cp_matrix_vec_in_chunk
     FStar.Math.Lemmas.small_div k (chunk et);
     assert (chunk_idx == tid + it * nthr);
     FStar.Math.Lemmas.lemma_mod_plus tid it nthr
+
+let em_fade'
+  (#et : Type0) {| scalar et, has_vec_cpy et |}
+  (#rows #cols : pos)
+  (em1 : ematrix et rows cols)
+  (em2 : ematrix et rows cols)
+  (nthr : pos)
+  (it: nat)
+  (row : nat)
+  (col: nat)
+  (k: nat)
+  : ematrix et rows cols
+= mkM (fun i j ->
+              let flat_idx = i * cols + j <: nat in
+              let chunk_idx = flat_idx / (chunk et) in
+              if (chunk_idx / nthr < it || (i = row && (col <= j && j < col + k)))
+              then macc em2 i j
+              else macc em1 i j)
+
+let em_fade'_fade_aux
+  (et : Type0) {| scalar et, has_vec_cpy et |}
+  (rows cols: pos)
+  (nthr : pos)
+  (tid: nat)
+  (it: nat)
+  (sq: squash (
+    chunk et /?+ cols /\
+    chunk et * nthr /?+ (rows * cols) /\
+    tid < nthr /\
+    it < (rows*cols) / (nthr * chunk et)
+  ))
+  (i j: nat)
+: Lemma
+  (requires (
+    let flat_idx = i * cols + j <: nat in
+    let chunk_idx = flat_idx / (chunk et) in
+    i < rows /\ j < cols /\
+    chunk_idx / nthr = it /\
+    chunk_idx % nthr == tid
+  ))
+  (ensures (
+    let i0 = it * nthr * chunk et in
+    let offset = tid * chunk et in
+    let row = (i0 + offset) / cols in
+    let col = (i0 + offset) % cols in
+    let flat_idx = i * cols + j <: nat in
+    let chunk_idx = flat_idx / (chunk et) in
+    (
+      (i = row && (col <= j && j < col + chunk et))
+    )
+  ))
+= if (i < rows && j < cols)
+  then begin
+    let i0 = it * nthr * chunk et in
+    let offset = tid * chunk et in
+    let row = (i0 + offset) / cols in
+    let col = (i0 + offset) % cols in
+
+    let flat_idx = i * cols + j <: nat in
+    let chunk_idx = flat_idx / (chunk et) in
+    if chunk_idx / nthr = it && chunk_idx % nthr = tid
+    then begin
+      assert (chunk_idx == it * nthr + tid);
+      let flat_idx_rem = flat_idx % chunk et in
+      assert (flat_idx == it * nthr * chunk et + tid * chunk et + flat_idx_rem);
+      cp_matrix_vec_chunk_et_divides_col et rows cols nthr tid it ();
+      cp_matrix_vec_in_chunk et rows cols nthr tid it flat_idx_rem ();
+      FStar.Math.Lemmas.euclidean_division_definition (i0 + offset) cols;
+      lemma_eucl_unique cols row (col + flat_idx_rem) i j;
+      assert (i == row);
+      assert (j == col + flat_idx_rem)
+    end
+  end
+
+let em_fade'_fade
+  (#et : Type0) {| scalar et, has_vec_cpy et |}
+  (#rows #cols: pos)
+  (esrc : ematrix et rows cols)
+  (edst : ematrix et rows cols)
+  (nthr : pos)
+  (tid: nat)
+  (it: nat)
+  (sq: squash (
+    chunk et /?+ cols /\
+    tid < nthr /\
+    chunk et * nthr /?+ (rows * cols) /\
+    it < (rows*cols) / (nthr * chunk et)
+  ))
+: Lemma
+  (ensures (
+    let i0 = it * nthr * chunk et in
+    let offset = tid * chunk et in
+    let row = (i0 + offset) / cols in
+    let col = (i0 + offset) % cols in
+    coincide_on_tid nthr tid (em_fade edst esrc nthr (it + 1))
+      (em_fade' edst esrc nthr it row col (chunk et))
+  ))
+= let i0 = it * nthr * chunk et in
+  let offset = tid * chunk et in
+  let row = (i0 + offset) / cols in
+  let col = (i0 + offset) % cols in
+  coincide_on_tid_intro nthr tid (em_fade edst esrc nthr (it + 1))
+      (em_fade' edst esrc nthr it row col (chunk et))
+      (fun i j ->
+        let flat_idx = i * cols + j <: nat in
+        let chunk_idx = flat_idx / chunk et in
+        if chunk_idx / nthr < it
+        then ()
+        else if chunk_idx / nthr = it
+        then em_fade'_fade_aux et rows cols nthr tid it () i j
+        else if i = row && (col <= j && j < col + (chunk et))
+        then ()
+        else begin
+          assert (chunk_idx / nthr > it);
+          assert (macc (em_fade edst esrc nthr (it + 1)) i j == macc edst i j);
+          assert (macc (em_fade' edst esrc nthr it row col (chunk et)) i j == macc edst i j);
+          ()
+        end
+      )
 
 #push-options "--z3rlimit 45 --fuel 0 --ifuel 1"
 // NB: The scalar constraint is only here so we can use 'zero' as an initializer
@@ -412,8 +609,11 @@ fn cp_matrix_vec
     while ((!k <^ chunk et))
       invariant live k ** pure (!k <= chunk et)
       invariant
-        exists* em'. // TODO: functional spec
-          own_strided_chunks dst em' nthr tid
+        exists* em'.
+          own_strided_chunks dst em' nthr tid **
+          pure (Kuiper.EMatrix.equal em'
+            (em_fade' edst esrc nthr ite row col !k)
+          )
     {
       with em'. unfold own_strided_chunks dst em' nthr tid;
       with vk . assert (pts_to k vk);
@@ -481,11 +681,8 @@ fn cp_matrix_vec
     add_helper vi vgit nthr (chunk et); // sigh
     assert pure (SZ.v !i == GR.read git * nthr * chunk et);
 
-    with em'. assert own_strided_chunks dst em' nthr tid;
-    assume pure (em' == em_fade edst esrc nthr (vgit + 1));
-    rewrite each em' as em_fade edst esrc nthr (vgit + 1) by nop_tactic ();
-    (* ^ FIXME: Without using a tactic, we get a goal where em_fade is
-         unfolded, which then fails... why does it unfold!? *)
+    em_fade'_fade esrc edst nthr tid vgit ();
+    own_strided_chunks_rw _ nthr tid _ (em_fade edst esrc nthr (vgit + 1));
     ()
   };
 

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.Copy.Vec.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.Copy.Vec.fst
@@ -233,6 +233,96 @@ let em_fade
 let nop_tactic () : Tactics.Tac unit = ()
 
 #push-options "--z3rlimit 75 --fuel 0 --ifuel 1"
+let cp_matrix_vec_chunk_et_divides_col
+  (et : Type0) {| scalar et, has_vec_cpy et |}
+  (rows cols: pos)
+  (nthr : pos)
+  (tid: nat)
+  (it: nat)
+  (sq: squash (
+    chunk et /?+ cols /\
+    tid < nthr /\
+    it <= (rows*cols) / (nthr * chunk et)
+  ))
+: Lemma
+  (ensures (
+    let i0 = it * nthr * chunk et in
+    let offset = tid * chunk et in
+    let row = (i0 + offset) / cols in
+    let col = (i0 + offset) % cols in
+    chunk et /?+ col
+  ))
+=
+    let i = it * nthr * chunk et in
+    let offset = tid * chunk et in
+    let row = (i + offset) / cols in
+    let col = (i + offset) % cols in
+    assert (chunk et /?+ offset);
+    assert (chunk et /?+ i);
+    lemma_nat_divides_pos_divides (chunk et) i;
+    assert (chunk et /? i);
+    lemma_nat_divides_pos_divides (chunk et) offset;
+    assert (chunk et /? offset);
+    lemma_divides_sum (chunk et) i offset;
+    assert ((chunk et /? (i + offset)));
+    lemma_nat_divides_pos_divides (chunk et) cols;
+    assert ((chunk et /? cols));
+    Kuiper.Math.Silly.lemma_mul_pos_recip rows cols;
+    assert ((cols > 0));
+    lemma_divides_mod_op (chunk et) (i + offset) cols;
+    assert (chunk et /? col);
+    lemma_nat_divides_pos_divides (chunk et) col
+
+let cp_matrix_vec_in_chunk
+  (et : Type0) {| scalar et, has_vec_cpy et |}
+  (rows cols: pos)
+  (nthr : pos)
+  (tid: nat)
+  (it: nat)
+  (k: nat)
+  (sq: squash (
+    chunk et /?+ cols /\
+    tid < nthr /\
+    it <= (rows*cols) / (nthr * chunk et) /\
+    k < chunk et /\ (
+    let i0 = it * nthr * chunk et in
+    let offset = tid * chunk et in
+    let row = (i0 + offset) / cols in
+    let col = (i0 + offset) % cols in
+    row < rows /\
+    col + k < cols
+  )))
+: Lemma
+  (ensures (
+    let i0 = it * nthr * chunk et in
+    let offset = tid * chunk et in
+    let row = (i0 + offset) / cols in
+    let col = (i0 + offset) % cols in
+    let ecell : (natlt rows & natlt cols) = Mktuple2 #(natlt rows) #(natlt cols) row (col + k) in
+    in_chunk (chunk et) rows cols nthr tid ecell
+  ))
+=
+    let i = it * nthr * chunk et in
+    let offset = tid * chunk et in
+    let row = (i + offset) / cols in
+    let col = (i + offset) % cols in
+    let ecell : (natlt rows & natlt cols) = Mktuple2 #(natlt rows) #(natlt cols) row (col + k) in
+    FStar.Math.Lemmas.euclidean_division_definition (i + offset) cols;
+    assert ((i + offset == row * cols + col));
+    let flat_idx = ((fst ecell * cols + snd ecell) <: nat) in
+    assert (flat_idx == i + offset + k);
+    let chunk_idx = (flat_idx / chunk et <: nat) in
+    FStar.Math.Lemmas.lemma_div_plus (i + k) tid (chunk et);
+    assert (chunk_idx == tid + (i + k) / chunk et);
+    FStar.Math.Lemmas.lemma_div_plus k (it * nthr) (chunk et);
+    assert (chunk_idx == tid + it * nthr + k / chunk et);
+    FStar.Math.Lemmas.small_div k (chunk et);
+    assert (chunk_idx == tid + it * nthr);
+    FStar.Math.Lemmas.lemma_mod_plus tid it nthr
+
+#push-options "--z3rlimit 45 --fuel 0 --ifuel 1"
+// NB: The scalar constraint is only here so we can use 'zero' as an initializer
+// for a local array... would be gone if we had uninitialized local arrays.
 inline_for_extraction noextract
 fn cp_matrix_vec
   (#et : Type0) {| scalar et, has_vec_cpy et |}
@@ -300,21 +390,7 @@ fn cp_matrix_vec
     let row = (!i +^ offset) /^ cols; assert (rewrites_to row ((!i +^ offset) /^ cols));
     let col = (!i +^ offset) %^ cols; assert (rewrites_to col ((!i +^ offset) %^ cols));
     assert pure (chunk et /?+ cols);
-    assert pure (chunk et /?+ offset);
-    assert pure (chunk et /?+ !i);
-    lemma_nat_divides_pos_divides (chunk et) !i;
-    assert pure (chunk et /? !i);
-    lemma_nat_divides_pos_divides (chunk et) offset;
-    assert pure (chunk et /? offset);
-    lemma_divides_sum (chunk et) !i offset;
-    assert (pure (chunk et /? (!i +^ offset)));
-    lemma_nat_divides_pos_divides (chunk et) cols;
-    assert (pure (chunk et /? cols));
-    Kuiper.Math.Silly.lemma_mul_pos_recip rows cols;
-    assert (pure (cols > 0));
-    lemma_divides_mod_op (chunk et) (!i +^ offset) cols;
-    assert pure (chunk et /? col);
-    lemma_nat_divides_pos_divides (chunk et) col;
+    cp_matrix_vec_chunk_et_divides_col et rows cols nthr tid (GR.read git) ();
     assert pure (chunk et /?+ col);
     assert (pure (col + chunk et <= cols));
     assert pure (SZ.v offset == tid * chunk et);
@@ -344,21 +420,8 @@ fn cp_matrix_vec
       Kuiper.Math.Silly.lemma_le_plus_lt col vk (chunk et) cols;
       assert pure (col + !k < cols);
       let ecell : erased (natlt rows & natlt cols) = Mktuple2 #(natlt rows) #(natlt cols) row (col +^ !k);
-
-      FStar.Math.Lemmas.euclidean_division_definition (!i + offset);
-      assert (pure (!i + offset == row * cols + col));
-      let flat_idx = Ghost.hide ((fst ecell * cols + snd ecell) <: nat);
-      assert pure (flat_idx == !i + offset + !k);
-      let chunk_idx = Ghost.hide (flat_idx / chunk et <: nat);
-      FStar.Math.Lemmas.lemma_div_plus (!i + !k) tid (chunk et);
-      assert pure (chunk_idx == tid + (!i + !k) / chunk et);
-      FStar.Math.Lemmas.lemma_div_plus !k (GR.read git * nthr) (chunk et);
-      assert pure (chunk_idx == tid + GR.read git * nthr + !k / chunk et);
-      FStar.Math.Lemmas.small_div !k (chunk et);
-      assert pure (chunk_idx == tid + GR.read git * nthr);
-      FStar.Math.Lemmas.lemma_mod_plus tid (GR.read git) nthr;
+      cp_matrix_vec_in_chunk et rows cols nthr tid (GR.read git) !k ();
       assert pure (in_chunk (chunk et) rows cols nthr tid ecell);
-
       forevery_remove'
         #(natlt rows & natlt cols)
         (fun (ij : (natlt rows & natlt cols)) -> in_chunk (chunk et) rows cols nthr tid ij)

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.Copy.Vec.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.Copy.Vec.fst
@@ -232,9 +232,7 @@ let em_fade
 
 let nop_tactic () : Tactics.Tac unit = ()
 
-#push-options "--z3rlimit 45 --fuel 0 --ifuel 1"
-// NB: The scalar constraint is only here so we can use 'zero' as an initializer
-// for a local array... would be gone if we had uninitialized local arrays.
+#push-options "--z3rlimit 60 --fuel 0 --ifuel 1"
 inline_for_extraction noextract
 fn cp_matrix_vec
   (#et : Type0) {| scalar et, has_vec_cpy et |}
@@ -304,7 +302,19 @@ fn cp_matrix_vec
     assert pure (chunk et /?+ cols);
     assert pure (chunk et /?+ offset);
     assert pure (chunk et /?+ !i);
+    lemma_nat_divides_pos_divides (chunk et) !i;
+    assert pure (chunk et /? !i);
+    lemma_nat_divides_pos_divides (chunk et) offset;
+    assert pure (chunk et /? offset);
+    lemma_divides_sum (chunk et) !i offset;
+    assert (pure (chunk et /? (!i +^ offset)));
+    lemma_nat_divides_pos_divides (chunk et) cols;
+    assert (pure (chunk et /? cols));
+    Kuiper.Math.Silly.lemma_mul_pos_recip rows cols;
+    assert (pure (cols > 0));
     lemma_divides_mod_op (chunk et) (!i +^ offset) cols;
+    assert pure (chunk et /? col);
+    lemma_nat_divides_pos_divides (chunk et) col;
     assert pure (chunk et /?+ col);
     assert (pure (col + chunk et <= cols));
     assert pure (SZ.v offset == tid * chunk et);

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.Copy.Vec.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.Copy.Vec.fst
@@ -344,7 +344,21 @@ fn cp_matrix_vec
       Kuiper.Math.Silly.lemma_le_plus_lt col vk (chunk et) cols;
       assert pure (col + !k < cols);
       let ecell : erased (natlt rows & natlt cols) = Mktuple2 #(natlt rows) #(natlt cols) row (col +^ !k);
-      assume pure (in_chunk (chunk et) rows cols nthr tid ecell);
+
+      FStar.Math.Lemmas.euclidean_division_definition (!i + offset);
+      assert (pure (!i + offset == row * cols + col));
+      let flat_idx = Ghost.hide ((fst ecell * cols + snd ecell) <: nat);
+      assert pure (flat_idx == !i + offset + !k);
+      let chunk_idx = Ghost.hide (flat_idx / chunk et <: nat);
+      FStar.Math.Lemmas.lemma_div_plus (!i + !k) tid (chunk et);
+      assert pure (chunk_idx == tid + (!i + !k) / chunk et);
+      FStar.Math.Lemmas.lemma_div_plus !k (GR.read git * nthr) (chunk et);
+      assert pure (chunk_idx == tid + GR.read git * nthr + !k / chunk et);
+      FStar.Math.Lemmas.small_div !k (chunk et);
+      assert pure (chunk_idx == tid + GR.read git * nthr);
+      FStar.Math.Lemmas.lemma_mod_plus tid (GR.read git) nthr;
+      assert pure (in_chunk (chunk et) rows cols nthr tid ecell);
+
       forevery_remove'
         #(natlt rows & natlt cols)
         (fun (ij : (natlt rows & natlt cols)) -> in_chunk (chunk et) rows cols nthr tid ij)


### PR DESCRIPTION
This PR proves all remaining `assume`s in Kuiper.Poly.GEMM.Copy.Vec, including functional correctness of `cp_matrix_vec`.

**Not** covered by this PR are the following 2 remaining `assume`s:
```
  // These should be exposed to the precondition and bubbled up.
  assume pure (chunk et /?+ src_str.stride);
  assume pure (chunk et /?+ src_str.offset);
```
