### PR TITLE
Model `launch_kernel_full_sync`

### DIFF
--- a/src/lib/kuiper/Kuiper.Array.Core.fst
+++ b/src/lib/kuiper/Kuiper.Array.Core.fst
@@ -118,7 +118,6 @@ fn gpu_array_alloc_vis
   (sz : SZ.t)
   (l:loc_id)
   (vis:visibility)
-  preserves cpu
   returns  x : gpu_array a (SZ.v sz)
   ensures
     exists* (s:seq a). 
@@ -170,6 +169,25 @@ fn gpu_array_alloc
   x
 }
 
+fn gpu_array_free_gen // needed for Kuiper.Kernel.Sync.free_c_shmems (to model launch_kernel_full_sync), to model allocation and liberation of per-block shared memory by the GPU runtime.
+  (#a:Type u#0)
+  (#sz:erased nat)
+  (r : gpu_array a sz)
+  (#v : erased (seq a))
+  (l: loc_id)
+  requires on l (r |-> v)
+  ensures  emp
+{
+  impersonate unit l (on l (r |-> v)) (fun _ -> emp) fn _ {
+    on_elim _;
+    unfold gpu_pts_to_array;
+    unfold gpu_pts_to_slice;
+    A.mask_mext r (fun _ -> True);
+    A.mask_free r;
+  };
+}
+
+
 fn gpu_array_free
   (#a:Type u#0)
   (#sz:erased nat)
@@ -179,13 +197,7 @@ fn gpu_array_free
   requires on gpu_loc (r |-> v)
   ensures  emp
 {
-  impersonate unit gpu_loc (on gpu_loc (r |-> v)) (fun _ -> emp) fn _ {
-    on_elim _;
-    unfold gpu_pts_to_array;
-    unfold gpu_pts_to_slice;
-    A.mask_mext r (fun _ -> True);
-    A.mask_free r;
-  };
+  gpu_array_free_gen r gpu_loc
 }
 
 [@@noextract_to "krml"]

--- a/src/lib/kuiper/Kuiper.Base.fsti
+++ b/src/lib/kuiper/Kuiper.Base.fsti
@@ -21,15 +21,27 @@ val block_of : visibility
 val block_of_idem (l:loc_id) : Lemma (block_of (block_of l) == l)
 val block_id_of : loc_id -> GTot int
 
-val gpu_id_loc (gpu_id:int) : l:loc_id { gpu_of l == l /\ gpu_id_of l == gpu_id }
+val gpu_id_loc (gpu_id:int) : l:loc_id { gpu_of l == l }
+val gpu_id_loc_lemma (gpu_id:int) : Lemma
+  (let l = gpu_id_loc gpu_id in
+    gpu_id_of l == gpu_id 
+  )
 let gpu_loc = gpu_id_loc 0
 
 val block_id_loc (#[T.exact (`0)]gpu_id:int) (bid:int)
-: l:loc_id { gpu_of l == gpu_id_loc gpu_id /\ block_id_of l == bid /\ block_of l == l }
+: l:loc_id { gpu_of l == gpu_id_loc gpu_id }
+val block_id_loc_lemma (#[T.exact (`0)]gpu_id:int) (bid:int) : Lemma
+  (let l = block_id_loc #gpu_id bid in
+    block_id_of l == bid /\ block_of l == l
+  )
 
-val thread_id_of (l:loc_id) : GTot int
 val thread_id_loc (#[T.exact (`0)]gpu_id:int) (bid tid:int)
-: l:loc_id { thread_id_of l == tid /\ block_id_of l == bid /\ gpu_id_of l == gpu_id /\ block_of l == block_id_loc #gpu_id bid /\ gpu_of l == gpu_id_loc gpu_id } 
+: l:loc_id { block_of l == block_id_loc #gpu_id bid /\ gpu_of l == gpu_id_loc gpu_id } 
+val thread_id_of (l:loc_id) : GTot int
+val thread_id_loc_lemma (#[T.exact (`0)]gpu_id:int) (bid tid:int) : Lemma
+  (let l = thread_id_loc #gpu_id bid tid in
+    thread_id_of l == tid /\ block_id_of l == bid /\ gpu_id_of l == gpu_id
+  )
 
 //locations that agree on their blocks are on the same gpu
 val block_of_same_gpu (l0 l1:_{block_of l0 == block_of l1})

--- a/src/lib/kuiper/Kuiper.Base.fsti
+++ b/src/lib/kuiper/Kuiper.Base.fsti
@@ -21,15 +21,15 @@ val block_of : visibility
 val block_of_idem (l:loc_id) : Lemma (block_of (block_of l) == l)
 val block_id_of : loc_id -> GTot int
 
-val gpu_id_loc (gpu_id:int) : l:loc_id { gpu_of l == l }
+val gpu_id_loc (gpu_id:int) : l:loc_id { gpu_of l == l /\ gpu_id_of l == gpu_id }
 let gpu_loc = gpu_id_loc 0
 
 val block_id_loc (#[T.exact (`0)]gpu_id:int) (bid:int)
-: l:loc_id { gpu_of l == gpu_id_loc gpu_id }
+: l:loc_id { gpu_of l == gpu_id_loc gpu_id /\ block_id_of l == bid /\ block_of l == l }
 
-val thread_id_loc (#[T.exact (`0)]gpu_id:int) (bid tid:int)
-: l:loc_id { block_of l == block_id_loc #gpu_id bid /\ gpu_of l == gpu_id_loc gpu_id } 
 val thread_id_of (l:loc_id) : GTot int
+val thread_id_loc (#[T.exact (`0)]gpu_id:int) (bid tid:int)
+: l:loc_id { thread_id_of l == tid /\ block_id_of l == bid /\ gpu_id_of l == gpu_id /\ block_of l == block_id_loc #gpu_id bid /\ gpu_of l == gpu_id_loc gpu_id } 
 
 //locations that agree on their blocks are on the same gpu
 val block_of_same_gpu (l0 l1:_{block_of l0 == block_of l1})

--- a/src/lib/kuiper/Kuiper.Kernel.Par.fst
+++ b/src/lib/kuiper/Kuiper.Kernel.Par.fst
@@ -1,0 +1,30 @@
+module Kuiper.Kernel.Par
+open Pulse
+open Pulse.Lib.ConditionVar
+ 
+#lang-pulse
+ 
+fn par (#preL: slprop) #postL #preR #postR (vis: visibility) #l0 (l: loc_id)
+  {| is_send_across vis preL, is_send_across vis postL |}
+  (f:unit -> stt unit (loc l ** preL) (fun _ -> loc l ** postL))
+  (g:unit -> stt unit preR (fun _ -> postR))
+  preserves loc l0 ** pure (vis l0 == vis l)
+  requires preL ** preR
+  ensures postL ** postR
+{
+  on_intro preL;
+  let c = create (on l0 postL) #_;
+  fork' (on l0 preL ** send c (on l0 postL)) fn _ {
+    impersonate unit l (on l0 preL) (fun _ -> on l0 postL) fn _ {
+      is_send_across_elim vis preL #_ l;
+      on_elim _;
+      f ();
+      on_intro postL;
+      is_send_across_elim vis postL #_ l0;
+    };
+    signal c #(on l0 postL);
+  };
+  g ();
+  wait c #(on l0 postL);
+  on_elim postL;
+}

--- a/src/lib/kuiper/Kuiper.Kernel.Sync.fst
+++ b/src/lib/kuiper/Kuiper.Kernel.Sync.fst
@@ -106,6 +106,7 @@ ensures
     let send_pre = k.kpre_sendable sh () bid tid;
     let send_post = k.kpost_sendable sh () bid tid;
     let tloc = thread_id_loc bid tid;
+    thread_id_loc_lemma bid tid;
     unfold (block_id k.nblk bid);
     loc_dup _;
     fold (block_id k.nblk bid);
@@ -184,6 +185,7 @@ ensures
     let send_pre = k.block_pre_sendable bid;
     let send_post = k.block_post_sendable bid;
     let bloc = block_id_loc bid;
+    block_id_loc_lemma bid;
     unfold gpu;
     loc_dup _;
     fold gpu;
@@ -219,6 +221,7 @@ fn launch_kernel_full_sync
     cpu **
     on gpu_loc full_post
 {
+  gpu_id_loc_lemma 0;
   impersonate
     unit
     gpu_loc

--- a/src/lib/kuiper/Kuiper.Kernel.Sync.fst
+++ b/src/lib/kuiper/Kuiper.Kernel.Sync.fst
@@ -1,27 +1,20 @@
 module Kuiper.Kernel.Sync
 #lang-pulse
-
-open Pulse.Lib.Core
-open Kuiper.Common
-open Kuiper.ForEvery
-open Kuiper.Base
-open Kuiper.SizeT
-include Kuiper.Kernel.Base
-include Kuiper.Kernel.Desc
-open FStar.Tactics.Typeclasses
+open Pulse.Lib.Pervasives
+friend Kuiper.Array.Core // for gpu_array_alloc_vis, gpu_array_free_gen
 
 module Par = Pulse.Lib.Par
 
 (* A model for launch_kernel_sync *)
 
-#push-options "--print_implicits"
-
 module SH = Kuiper.SHMem
 
+// Models the allocation of per-block shared memory by the GPU runtime.
 noextract
 fn rec alloc_c_shmems
+  (block_loc: loc_id)
   (d: list SH.shmem_desc)
-requires emp
+preserves loc block_loc
 returns res: SH.c_shmems d
 ensures SH.live_c_shmems res
 ensures pure (SH.c_shmems_inv res)
@@ -35,8 +28,53 @@ ensures pure (SH.c_shmems_inv res)
         as SH.live_c_shmems res;
       res
     }
+    norewrite
     Cons a q -> {
-      admit ()
+      let resq = alloc_c_shmems block_loc q;
+      let resa' = Kuiper.Array.Core.gpu_array_alloc_vis #a.ty #a.sized a.len block_loc block_of;
+      let resa : SH.c_shmem a = coerce_eq () resa';
+      on_elim _;
+      with s . rewrite (resa' |-> s) as (Kuiper.Array.Core.gpu_pts_to_array #a.ty #a.len resa s);
+      SH.fold_live_c_shmem resa;
+      let res : SH.c_shmems d = (resa, resq);
+      rewrite each resa as fst #(SH.c_shmem a) #(SH.c_shmems q) res;
+      rewrite each resq as snd #(SH.c_shmem a) #(SH.c_shmems q) res;
+      SH.fold_live_c_shmems_cons #a #q res #1.0R;
+      rewrite each (a :: q) as d;
+      res
+    }
+  }
+}
+
+// Models the liberation of per-block shared memory by the GPU runtime.
+noextract
+fn rec free_c_shmems
+  (block_loc: loc_id)
+  (d: list SH.shmem_desc)
+  (res: SH.c_shmems d)
+preserves loc block_loc
+requires SH.live_c_shmems res
+requires pure (SH.c_shmems_inv res)
+{
+  match d {
+    Nil -> {
+      SH.unfold_live_c_shmems_nil res #1.0R;
+    }
+    Cons a q -> {
+      let res' : SH.c_shmems (a :: q) = res;
+      rewrite each res as res';
+      SH.unfold_live_c_shmems_cons #a #q res' #1.0R;
+      let resq : SH.c_shmems q = snd res';
+      rewrite each (snd res') as resq;
+      free_c_shmems block_loc q resq;
+      let resa : SH.c_shmem a = fst res';
+      rewrite each (fst res') as resa;
+      SH.unfold_live_c_shmem resa;
+      let resa' : Kuiper.Array.Core.gpu_array a.ty a.len = resa;
+      with s . rewrite (Kuiper.Array.Core.gpu_pts_to_array #a.ty #a.len resa s) as (resa' |-> s);
+      with s . assert (resa' |-> s);
+      on_intro (resa' |-> s);
+      Kuiper.Array.Core.gpu_array_free_gen resa' block_loc;
     }
   }
 }
@@ -111,12 +149,16 @@ ensures
   block_id k.nblk bid **
   k.block_post bid
 {
-  let sh = alloc_c_shmems k.shmems_desc;
+  unfold (block_id k.nblk bid);
+  let sh = alloc_c_shmems _ k.shmems_desc;
+  fold (block_id k.nblk bid);
   assume (can_create_barrier k.nthr);
   let _ : unit = Mkkernel_desc?.block_setup k sh bid ();
   run_block_threads k bid sh k.nthr;
   Mkkernel_desc?.block_teardown k sh bid ();
-  drop_ (SH.live_c_shmems sh); // assume free_c_shmems
+  unfold (block_id k.nblk bid);
+  free_c_shmems _ _ sh;
+  fold (block_id k.nblk bid);
   drop_ consumed_can_create_barrier; // assume
 }
 

--- a/src/lib/kuiper/Kuiper.Kernel.Sync.fst
+++ b/src/lib/kuiper/Kuiper.Kernel.Sync.fst
@@ -1,0 +1,195 @@
+module Kuiper.Kernel.Sync
+#lang-pulse
+
+open Pulse.Lib.Core
+open Kuiper.Common
+open Kuiper.ForEvery
+open Kuiper.Base
+open Kuiper.SizeT
+include Kuiper.Kernel.Base
+include Kuiper.Kernel.Desc
+open FStar.Tactics.Typeclasses
+
+module Par = Pulse.Lib.Par
+
+(* A model for launch_kernel_sync *)
+
+#push-options "--print_implicits"
+
+module SH = Kuiper.SHMem
+
+noextract
+fn rec alloc_c_shmems
+  (d: list SH.shmem_desc)
+requires emp
+returns res: SH.c_shmems d
+ensures SH.live_c_shmems res
+ensures pure (SH.c_shmems_inv res)
+{
+  match d {
+    norewrite
+    Nil -> {
+      let res : SH.c_shmems d = 0;
+      SH.fold_live_c_shmems_nil res #1.0R;
+      rewrite SH.live_c_shmems #[] res
+        as SH.live_c_shmems res;
+      res
+    }
+    Cons a q -> {
+      admit ()
+    }
+  }
+}
+
+inline_for_extraction noextract
+let szlt_coerce #m #n (i: szlt n { i < m }) : szlt m = i
+
+noextract
+fn rec run_block_threads
+  (#full_pre : slprop)
+  (#full_post : slprop)
+  (k : kernel_desc full_pre full_post)
+  (bid: szlt k.nblk)
+  (sh: SH.c_shmems k.shmems_desc {SH.c_shmems_inv sh})
+  (upto: sz { upto <= k.nthr})
+preserves block_id k.nblk bid
+requires
+  (forall+ (i : natlt upto). k.kpre sh bid (natlt_coerce i))
+ensures
+  (forall+ (i : natlt upto). k.kpost sh bid (natlt_coerce i))
+{
+  if (upto = 0sz) {
+    forevery_elim_empty _;
+    forevery_intro_empty (fun (i : natlt upto) -> k.kpost sh bid (natlt_coerce i))
+  } else {
+    forevery_natlt_pop upto (fun (i: natlt upto) -> k.kpre sh bid (natlt_coerce i));
+    let tid : szlt k.nthr = upto -^ 1sz;
+    rewrite each (upto - 1) as tid;
+    let send_pre = k.kpre_sendable sh () bid tid;
+    let send_post = k.kpost_sendable sh () bid tid;
+    let tloc = thread_id_loc bid tid;
+    unfold (block_id k.nblk bid);
+    loc_dup _;
+    fold (block_id k.nblk bid);
+    Kuiper.Kernel.Par.par
+      #(k.kpre sh bid tid)
+      #(k.kpost sh bid tid)
+      #(block_id k.nblk bid ** forall+ (i : natlt tid). k.kpre sh bid (natlt_coerce i))
+      #(block_id k.nblk bid ** forall+ (i : natlt tid). k.kpost sh bid (natlt_coerce i))
+      block_of tloc
+      fn _ {
+        loc_dup tloc;
+        fold (thread_id k.nthr tid);
+        loc_dup tloc;
+        fold (block_id k.nblk bid);
+        loc_dup tloc;
+        fold gpu;
+        Mkkernel_desc?.f k sh bid tid ();
+        drop_ gpu; // from the loc_dup above
+        drop_ (block_id _ _); // from the loc_dup above
+        drop_ (thread_id _ _); // from the loc_dup above
+      }
+      fn _ {
+        run_block_threads k bid sh tid
+      };
+    drop_ (loc _); // from the loc_dup above
+    rewrite each (v tid) as (upto - 1);
+    forevery_natlt_push upto (fun (i: natlt upto) -> k.kpost sh bid (natlt_coerce i));
+  }
+}
+
+noextract
+fn rec run_block 
+  (#full_pre : slprop)
+  (#full_post : slprop)
+  (k : kernel_desc full_pre full_post)
+  (bid: szlt k.nblk)
+requires
+  block_id k.nblk bid **
+  k.block_pre bid
+ensures
+  block_id k.nblk bid **
+  k.block_post bid
+{
+  let sh = alloc_c_shmems k.shmems_desc;
+  assume (can_create_barrier k.nthr);
+  let _ : unit = Mkkernel_desc?.block_setup k sh bid ();
+  run_block_threads k bid sh k.nthr;
+  Mkkernel_desc?.block_teardown k sh bid ();
+  drop_ (SH.live_c_shmems sh); // assume free_c_shmems
+  drop_ consumed_can_create_barrier; // assume
+}
+
+noextract
+fn rec run_blocks
+  (#full_pre : slprop)
+  (#full_post : slprop)
+  (k : kernel_desc full_pre full_post)
+  (upto: sz { upto <= k.nblk})
+preserves gpu
+requires
+  (forall+ (i : natlt upto). k.block_pre (natlt_coerce i))
+ensures
+  (forall+ (i : natlt upto). k.block_post (natlt_coerce i))
+{
+  if (upto = 0sz) {
+    forevery_elim_empty _;
+    forevery_intro_empty (fun (i : natlt upto) -> k.block_post (natlt_coerce i))
+  } else {
+    forevery_natlt_pop upto (fun (i: natlt upto) -> k.block_pre (natlt_coerce i));
+    let bid : szlt k.nblk = upto -^ 1sz;
+    rewrite each (upto - 1) as bid;
+    let send_pre = k.block_pre_sendable bid;
+    let send_post = k.block_post_sendable bid;
+    let bloc = block_id_loc bid;
+    unfold gpu;
+    loc_dup _;
+    fold gpu;
+    Kuiper.Kernel.Par.par
+      #(k.block_pre bid)
+      #(k.block_post bid)
+      #(gpu ** forall+ (i : natlt bid). k.block_pre (natlt_coerce i))
+      #(gpu ** forall+ (i : natlt bid). k.block_post (natlt_coerce i))
+      gpu_of bloc
+      fn _ {
+        loc_dup bloc;
+        fold (block_id k.nblk bid);
+        run_block k bid;
+        drop_ (block_id _ _); // from the loc_dup above
+      }
+      fn _ {
+        run_blocks k bid
+      };
+    drop_ (loc _); // from the loc_dup above
+    rewrite each (v bid) as (upto - 1);
+    forevery_natlt_push upto (fun (i: natlt upto) -> k.block_post (natlt_coerce i));
+  }
+}
+
+noextract
+fn launch_kernel_full_sync
+  (#full_pre #full_post : slprop)
+  (k : kernel_desc full_pre full_post)
+  requires
+    cpu **
+    on gpu_loc full_pre
+  ensures
+    cpu **
+    on gpu_loc full_post
+{
+  impersonate
+    unit
+    gpu_loc
+    (on gpu_loc full_pre)
+    (fun _ -> on gpu_loc full_post)
+    fn _ {
+      loc_dup _;
+      fold gpu;
+      on_elim full_pre;
+      Mkkernel_desc?.setup k ();
+      run_blocks k k.nblk;
+      Mkkernel_desc?.teardown k ();
+      on_intro full_post;
+      drop_ gpu; // from loc_dup
+    };
+}

--- a/src/lib/kuiper/Kuiper.Kernel.Sync.fsti
+++ b/src/lib/kuiper/Kuiper.Kernel.Sync.fsti
@@ -1,0 +1,23 @@
+module Kuiper.Kernel.Sync
+#lang-pulse
+open Pulse.Lib.Core
+open Kuiper.Common
+open Kuiper.ForEvery
+open Kuiper.Base
+open Kuiper.SizeT
+include Kuiper.Kernel.Base
+include Kuiper.Kernel.Desc
+open FStar.Tactics.Typeclasses
+
+(* A model for launch_kernel_sync *)
+
+noextract
+fn launch_kernel_full_sync
+  (#full_pre #full_post : slprop)
+  (k : kernel_desc full_pre full_post)
+  requires
+    cpu **
+    on gpu_loc full_pre
+  ensures
+    cpu **
+    on gpu_loc full_post


### PR DESCRIPTION
This PR creates a new module, `Kuiper.Kernel.Sync`, to give a full model of `Kuiper.Kernel.launch_kernel_full_sync`: instead of relying on `Kuiper.Kernel.Base.launch_kernel_full`, I am relying on a location-aware parallel composition operator introduced by @gebner in `Kuiper.Kernel.Par`.

This PR also models allocation and liberation of per-block shared memory, which cannot be done by the user-facing API (`gpu_array_alloc`, `gpu_array_free`), so, as advised by @nikswamy, I need to friend `Kuiper.Array.Core.fst` and use internal helpers from there instead.
