### PR TITLE
KernelDesc: bake in barrier contract instead of allowing creation

### DIFF
--- a/dist/Kuiper_GEMM_TensorCore.cu
+++ b/dist/Kuiper_GEMM_TensorCore.cu
@@ -5,8 +5,9 @@ __global__
 /**
   hoisted when extracting g_gemm_f16_f16_64x64x16_16x16x16
 */
-static void __hoisted_0(uint32_t shared, uint32_t cols, half *gA, half *gB,
-                        half *gC)
+static void
+__hoisted_0(uint32_t shared, uint32_t cols, half *gA, half *gB, half *gC,
+            uint32_t nthr)
 {
     half *sA = (half *) KPR_SHMEM_AT(0U);
     half *sB = (half *) KPR_SHMEM_AT(2048U);
@@ -31,29 +32,46 @@ static void __hoisted_0(uint32_t shared, uint32_t cols, half *gA, half *gB,
     uint32_t bkIdx = 0U;
     for (; bkIdx < num_k_tiles; bkIdx++) {
         __syncthreads();
-        uint32_t __anf01 = bkIdx;
+        uint32_t __anf02 = bkIdx;
         half *tileA = gA;
-        uint32_t i0 = threadIdx.x;
-        for (; i0 < 1024U; i0 += 512U)
-            sA[i0] =
-                tileA[(mrow * 64U + i0 / 16U) * shared + __anf01 * 16U +
-                      i0 % 16U];
+        uint32_t i0 = 0U;
+        for (; i0 < 1024U; i0 += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i0 + threadIdx.x * 8U) / 16U;
+            uint32_t col = (i0 + threadIdx.x * 8U) % 16U;
+            vec_memcpy(local,
+                       tileA + shared * (mrow * 64U) + __anf02 * 16U +
+                       shared * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sA[row * 16U + col + k] = local[k];
+        }
         half *tileB = gB;
-        uint32_t i = threadIdx.x;
-        for (; i < 1024U; i += 512U)
-            sB[i] =
-                tileB[(__anf01 * 16U + i / 64U) * cols + mcol * 64U + i % 64U];
+        uint32_t i = 0U;
+        for (; i < 1024U; i += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i + threadIdx.x * 8U) / 64U;
+            uint32_t col = (i + threadIdx.x * 8U) % 64U;
+            vec_memcpy(local,
+                       tileB + cols * (__anf02 * 16U) + mcol * 64U +
+                       cols * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sB[row * 64U + col + k] = local[k];
+        }
         __syncthreads();
         uint32_t dotIdx = 0U;
         for (; dotIdx < 1U; dotIdx++) {
-            uint32_t __anf04 = dotIdx;
             uint32_t __anf05 = dotIdx;
+            uint32_t __anf06 = dotIdx;
             half *b_tile = sB;
             wmma::load_matrix_sync(aFrag,
                                    sA + 16U * (threadIdx.x / 32U / 4U * 16U) +
-                                   __anf04 * 16U, 16U);
+                                   __anf05 * 16U, 16U);
             wmma::load_matrix_sync(bFrag,
-                                   b_tile + 64U * (__anf05 * 16U) +
+                                   b_tile + 64U * (__anf06 * 16U) +
                                    threadIdx.x / 32U % 4U * 16U, 64U);
             wmma::mma_sync(accumFrag, aFrag, bFrag, accumFrag);
         }
@@ -77,10 +95,11 @@ Kuiper_GEMM_TensorCore_g_gemm_f16_f16_64x64x16_16x16x16(uint32_t rows,
     KPR_GUARD(shared % 16U == 0U);
     KPR_GUARD(cols % 64U == 0U);
     uint32_t nblk = rows / 64U * (cols / 64U);
+    KPR_ASSERT(nblk <= 2097152U);
     KPR_SHMEM_FITS(4096U);
     MUST(cudaFuncSetAttribute
          (__hoisted_0, cudaFuncAttributeMaxDynamicSharedMemorySize, 4096U));
-    KPR_KCALL(__hoisted_0, nblk, 512U, 4096U, shared, cols, gA, gB, gC);
+    KPR_KCALL(__hoisted_0, nblk, 512U, 4096U, shared, cols, gA, gB, gC, 512U);
     MUST(cudaDeviceSynchronize());
 }
 
@@ -88,8 +107,9 @@ __global__
 /**
   hoisted when extracting g_gemm_f16_f16_32x32x32_32x8x16
 */
-static void __hoisted_1(uint32_t shared, uint32_t cols, half *gA, half *gB,
-                        half *gC)
+static void
+__hoisted_1(uint32_t shared, uint32_t cols, half *gA, half *gB, half *gC,
+            uint32_t nthr)
 {
     half *sA = (half *) KPR_SHMEM_AT(0U);
     half *sB = (half *) KPR_SHMEM_AT(2048U);
@@ -114,29 +134,46 @@ static void __hoisted_1(uint32_t shared, uint32_t cols, half *gA, half *gB,
     uint32_t bkIdx = 0U;
     for (; bkIdx < num_k_tiles; bkIdx++) {
         __syncthreads();
-        uint32_t __anf01 = bkIdx;
+        uint32_t __anf02 = bkIdx;
         half *tileA = gA;
-        uint32_t i0 = threadIdx.x;
-        for (; i0 < 1024U; i0 += 128U)
-            sA[i0] =
-                tileA[(mrow * 32U + i0 / 32U) * shared + __anf01 * 32U +
-                      i0 % 32U];
+        uint32_t i0 = 0U;
+        for (; i0 < 1024U; i0 += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i0 + threadIdx.x * 8U) / 32U;
+            uint32_t col = (i0 + threadIdx.x * 8U) % 32U;
+            vec_memcpy(local,
+                       tileA + shared * (mrow * 32U) + __anf02 * 32U +
+                       shared * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sA[row * 32U + col + k] = local[k];
+        }
         half *tileB = gB;
-        uint32_t i = threadIdx.x;
-        for (; i < 1024U; i += 128U)
-            sB[i] =
-                tileB[(__anf01 * 32U + i / 32U) * cols + mcol * 32U + i % 32U];
+        uint32_t i = 0U;
+        for (; i < 1024U; i += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i + threadIdx.x * 8U) / 32U;
+            uint32_t col = (i + threadIdx.x * 8U) % 32U;
+            vec_memcpy(local,
+                       tileB + cols * (__anf02 * 32U) + mcol * 32U +
+                       cols * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sB[row * 32U + col + k] = local[k];
+        }
         __syncthreads();
         uint32_t dotIdx = 0U;
         for (; dotIdx < 2U; dotIdx++) {
-            uint32_t __anf04 = dotIdx;
             uint32_t __anf05 = dotIdx;
+            uint32_t __anf06 = dotIdx;
             half *b_tile = sB;
             wmma::load_matrix_sync(aFrag,
                                    sA + 32U * (threadIdx.x / 32U / 4U * 32U) +
-                                   __anf04 * 16U, 32U);
+                                   __anf05 * 16U, 32U);
             wmma::load_matrix_sync(bFrag,
-                                   b_tile + 32U * (__anf05 * 16U) +
+                                   b_tile + 32U * (__anf06 * 16U) +
                                    threadIdx.x / 32U % 4U * 8U, 32U);
             wmma::mma_sync(accumFrag, aFrag, bFrag, accumFrag);
         }
@@ -160,10 +197,11 @@ Kuiper_GEMM_TensorCore_g_gemm_f16_f16_32x32x32_32x8x16(uint32_t rows,
     KPR_GUARD(shared % 32U == 0U);
     KPR_GUARD(cols % 32U == 0U);
     uint32_t nblk = rows / 32U * (cols / 32U);
+    KPR_ASSERT(nblk <= 2097152U);
     KPR_SHMEM_FITS(4096U);
     MUST(cudaFuncSetAttribute
          (__hoisted_1, cudaFuncAttributeMaxDynamicSharedMemorySize, 4096U));
-    KPR_KCALL(__hoisted_1, nblk, 128U, 4096U, shared, cols, gA, gB, gC);
+    KPR_KCALL(__hoisted_1, nblk, 128U, 4096U, shared, cols, gA, gB, gC, 128U);
     MUST(cudaDeviceSynchronize());
 }
 
@@ -171,8 +209,9 @@ __global__
 /**
   hoisted when extracting g_gemm_f16_f16_32x32x32_8x32x16
 */
-static void __hoisted_2(uint32_t shared, uint32_t cols, half *gA, half *gB,
-                        half *gC)
+static void
+__hoisted_2(uint32_t shared, uint32_t cols, half *gA, half *gB, half *gC,
+            uint32_t nthr)
 {
     half *sA = (half *) KPR_SHMEM_AT(0U);
     half *sB = (half *) KPR_SHMEM_AT(2048U);
@@ -196,28 +235,45 @@ static void __hoisted_2(uint32_t shared, uint32_t cols, half *gA, half *gB,
     uint32_t bkIdx = 0U;
     for (; bkIdx < num_k_tiles; bkIdx++) {
         __syncthreads();
-        uint32_t __anf01 = bkIdx;
+        uint32_t __anf02 = bkIdx;
         half *tileA = gA;
-        uint32_t i0 = threadIdx.x;
-        for (; i0 < 1024U; i0 += 128U)
-            sA[i0] =
-                tileA[(mrow * 32U + i0 / 32U) * shared + __anf01 * 32U +
-                      i0 % 32U];
+        uint32_t i0 = 0U;
+        for (; i0 < 1024U; i0 += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i0 + threadIdx.x * 8U) / 32U;
+            uint32_t col = (i0 + threadIdx.x * 8U) % 32U;
+            vec_memcpy(local,
+                       tileA + shared * (mrow * 32U) + __anf02 * 32U +
+                       shared * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sA[row * 32U + col + k] = local[k];
+        }
         half *tileB = gB;
-        uint32_t i = threadIdx.x;
-        for (; i < 1024U; i += 128U)
-            sB[i] =
-                tileB[(__anf01 * 32U + i / 32U) * cols + mcol * 32U + i % 32U];
+        uint32_t i = 0U;
+        for (; i < 1024U; i += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i + threadIdx.x * 8U) / 32U;
+            uint32_t col = (i + threadIdx.x * 8U) % 32U;
+            vec_memcpy(local,
+                       tileB + cols * (__anf02 * 32U) + mcol * 32U +
+                       cols * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sB[row * 32U + col + k] = local[k];
+        }
         __syncthreads();
         uint32_t dotIdx = 0U;
         for (; dotIdx < 2U; dotIdx++) {
-            uint32_t __anf04 = dotIdx;
             uint32_t __anf05 = dotIdx;
+            uint32_t __anf06 = dotIdx;
             half *b_tile = sB;
             wmma::load_matrix_sync(aFrag,
                                    sA + 32U * (threadIdx.x / 32U * 8U) +
-                                   __anf04 * 16U, 32U);
-            wmma::load_matrix_sync(bFrag, b_tile + 32U * (__anf05 * 16U), 32U);
+                                   __anf05 * 16U, 32U);
+            wmma::load_matrix_sync(bFrag, b_tile + 32U * (__anf06 * 16U), 32U);
             wmma::mma_sync(accumFrag, aFrag, bFrag, accumFrag);
         }
     }
@@ -239,10 +295,11 @@ Kuiper_GEMM_TensorCore_g_gemm_f16_f16_32x32x32_8x32x16(uint32_t rows,
     KPR_GUARD(shared % 32U == 0U);
     KPR_GUARD(cols % 32U == 0U);
     uint32_t nblk = rows / 32U * (cols / 32U);
+    KPR_ASSERT(nblk <= 2097152U);
     KPR_SHMEM_FITS(4096U);
     MUST(cudaFuncSetAttribute
          (__hoisted_2, cudaFuncAttributeMaxDynamicSharedMemorySize, 4096U));
-    KPR_KCALL(__hoisted_2, nblk, 128U, 4096U, shared, cols, gA, gB, gC);
+    KPR_KCALL(__hoisted_2, nblk, 128U, 4096U, shared, cols, gA, gB, gC, 128U);
     MUST(cudaDeviceSynchronize());
 }
 
@@ -250,8 +307,9 @@ __global__
 /**
   hoisted when extracting g_gemm_f16_f16_32x8x16_32x8x16
 */
-static void __hoisted_3(uint32_t shared, uint32_t cols, half *gA, half *gB,
-                        half *gC)
+static void
+__hoisted_3(uint32_t shared, uint32_t cols, half *gA, half *gB, half *gC,
+            uint32_t nthr)
 {
     half *sA = (half *) KPR_SHMEM_AT(0U);
     half *sB = (half *) KPR_SHMEM_AT(1024U);
@@ -275,27 +333,45 @@ static void __hoisted_3(uint32_t shared, uint32_t cols, half *gA, half *gB,
     uint32_t bkIdx = 0U;
     for (; bkIdx < num_k_tiles; bkIdx++) {
         __syncthreads();
-        uint32_t __anf01 = bkIdx;
+        uint32_t __anf02 = bkIdx;
         half *tileA = gA;
-        uint32_t i0 = threadIdx.x;
-        for (; i0 < 512U; i0 += 32U)
-            sA[i0] =
-                tileA[(mrow * 32U + i0 / 16U) * shared + __anf01 * 16U +
-                      i0 % 16U];
+        uint32_t i0 = 0U;
+        for (; i0 < 512U; i0 += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i0 + threadIdx.x * 8U) / 16U;
+            uint32_t col = (i0 + threadIdx.x * 8U) % 16U;
+            vec_memcpy(local,
+                       tileA + shared * (mrow * 32U) + __anf02 * 16U +
+                       shared * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sA[row * 16U + col + k] = local[k];
+        }
         half *tileB = gB;
-        uint32_t i = threadIdx.x;
-        for (; i < 128U; i += 32U)
-            sB[i] = tileB[(__anf01 * 16U + i / 8U) * cols + mcol * 8U + i % 8U];
+        uint32_t i = 0U;
+        for (; i < 128U; i += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i + threadIdx.x * 8U) / 8U;
+            uint32_t col = (i + threadIdx.x * 8U) % 8U;
+            vec_memcpy(local,
+                       tileB + cols * (__anf02 * 16U) + mcol * 8U + cols * row +
+                       col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sB[row * 8U + col + k] = local[k];
+        }
         __syncthreads();
         uint32_t dotIdx = 0U;
         for (; dotIdx < 1U; dotIdx++) {
-            uint32_t __anf04 = dotIdx;
             uint32_t __anf05 = dotIdx;
+            uint32_t __anf06 = dotIdx;
             half *b_tile = sB;
             wmma::load_matrix_sync(aFrag,
                                    sA + 16U * (threadIdx.x / 32U * 32U) +
-                                   __anf04 * 16U, 16U);
-            wmma::load_matrix_sync(bFrag, b_tile + 8U * (__anf05 * 16U), 8U);
+                                   __anf05 * 16U, 16U);
+            wmma::load_matrix_sync(bFrag, b_tile + 8U * (__anf06 * 16U), 8U);
             wmma::mma_sync(accumFrag, aFrag, bFrag, accumFrag);
         }
     }
@@ -317,10 +393,11 @@ Kuiper_GEMM_TensorCore_g_gemm_f16_f16_32x8x16_32x8x16(uint32_t rows,
     KPR_GUARD(shared % 16U == 0U);
     KPR_GUARD(cols % 8U == 0U);
     uint32_t nblk = rows / 32U * (cols / 8U);
+    KPR_ASSERT(nblk <= 2097152U);
     KPR_SHMEM_FITS(1280U);
     MUST(cudaFuncSetAttribute
          (__hoisted_3, cudaFuncAttributeMaxDynamicSharedMemorySize, 1280U));
-    KPR_KCALL(__hoisted_3, nblk, 32U, 1280U, shared, cols, gA, gB, gC);
+    KPR_KCALL(__hoisted_3, nblk, 32U, 1280U, shared, cols, gA, gB, gC, 32U);
     MUST(cudaDeviceSynchronize());
 }
 
@@ -328,8 +405,9 @@ __global__
 /**
   hoisted when extracting g_gemm_f16_f16_8x32x16_8x32x16
 */
-static void __hoisted_4(uint32_t shared, uint32_t cols, half *gA, half *gB,
-                        half *gC)
+static void
+__hoisted_4(uint32_t shared, uint32_t cols, half *gA, half *gB, half *gC,
+            uint32_t nthr)
 {
     half *sA = (half *) KPR_SHMEM_AT(0U);
     half *sB = (half *) KPR_SHMEM_AT(2048U);
@@ -353,28 +431,45 @@ static void __hoisted_4(uint32_t shared, uint32_t cols, half *gA, half *gB,
     uint32_t bkIdx = 0U;
     for (; bkIdx < num_k_tiles; bkIdx++) {
         __syncthreads();
-        uint32_t __anf01 = bkIdx;
+        uint32_t __anf02 = bkIdx;
         half *tileA = gA;
-        uint32_t i0 = threadIdx.x;
-        for (; i0 < 1024U; i0 += 128U)
-            sA[i0] =
-                tileA[(mrow * 32U + i0 / 32U) * shared + __anf01 * 32U +
-                      i0 % 32U];
+        uint32_t i0 = 0U;
+        for (; i0 < 1024U; i0 += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i0 + threadIdx.x * 8U) / 32U;
+            uint32_t col = (i0 + threadIdx.x * 8U) % 32U;
+            vec_memcpy(local,
+                       tileA + shared * (mrow * 32U) + __anf02 * 32U +
+                       shared * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sA[row * 32U + col + k] = local[k];
+        }
         half *tileB = gB;
-        uint32_t i = threadIdx.x;
-        for (; i < 1024U; i += 128U)
-            sB[i] =
-                tileB[(__anf01 * 32U + i / 32U) * cols + mcol * 32U + i % 32U];
+        uint32_t i = 0U;
+        for (; i < 1024U; i += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i + threadIdx.x * 8U) / 32U;
+            uint32_t col = (i + threadIdx.x * 8U) % 32U;
+            vec_memcpy(local,
+                       tileB + cols * (__anf02 * 32U) + mcol * 32U +
+                       cols * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sB[row * 32U + col + k] = local[k];
+        }
         __syncthreads();
         uint32_t dotIdx = 0U;
         for (; dotIdx < 2U; dotIdx++) {
-            uint32_t __anf04 = dotIdx;
             uint32_t __anf05 = dotIdx;
+            uint32_t __anf06 = dotIdx;
             half *b_tile = sB;
             wmma::load_matrix_sync(aFrag,
                                    sA + 32U * (threadIdx.x / 32U * 8U) +
-                                   __anf04 * 16U, 32U);
-            wmma::load_matrix_sync(bFrag, b_tile + 32U * (__anf05 * 16U), 32U);
+                                   __anf05 * 16U, 32U);
+            wmma::load_matrix_sync(bFrag, b_tile + 32U * (__anf06 * 16U), 32U);
             wmma::mma_sync(accumFrag, aFrag, bFrag, accumFrag);
         }
     }
@@ -396,10 +491,11 @@ Kuiper_GEMM_TensorCore_g_gemm_f16_f16_8x32x16_8x32x16(uint32_t rows,
     KPR_GUARD(shared % 32U == 0U);
     KPR_GUARD(cols % 32U == 0U);
     uint32_t nblk = rows / 32U * (cols / 32U);
+    KPR_ASSERT(nblk <= 2097152U);
     KPR_SHMEM_FITS(4096U);
     MUST(cudaFuncSetAttribute
          (__hoisted_4, cudaFuncAttributeMaxDynamicSharedMemorySize, 4096U));
-    KPR_KCALL(__hoisted_4, nblk, 128U, 4096U, shared, cols, gA, gB, gC);
+    KPR_KCALL(__hoisted_4, nblk, 128U, 4096U, shared, cols, gA, gB, gC, 128U);
     MUST(cudaDeviceSynchronize());
 }
 
@@ -407,8 +503,9 @@ __global__
 /**
   hoisted when extracting g_gemm_f16_f16_64x64x64_16x16x16
 */
-static void __hoisted_5(uint32_t shared, uint32_t cols, half *gA, half *gB,
-                        half *gC)
+static void
+__hoisted_5(uint32_t shared, uint32_t cols, half *gA, half *gB, half *gC,
+            uint32_t nthr)
 {
     half *sA = (half *) KPR_SHMEM_AT(0U);
     half *sB = (half *) KPR_SHMEM_AT(8192U);
@@ -433,29 +530,46 @@ static void __hoisted_5(uint32_t shared, uint32_t cols, half *gA, half *gB,
     uint32_t bkIdx = 0U;
     for (; bkIdx < num_k_tiles; bkIdx++) {
         __syncthreads();
-        uint32_t __anf01 = bkIdx;
+        uint32_t __anf02 = bkIdx;
         half *tileA = gA;
-        uint32_t i0 = threadIdx.x;
-        for (; i0 < 4096U; i0 += 512U)
-            sA[i0] =
-                tileA[(mrow * 64U + i0 / 64U) * shared + __anf01 * 64U +
-                      i0 % 64U];
+        uint32_t i0 = 0U;
+        for (; i0 < 4096U; i0 += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i0 + threadIdx.x * 8U) / 64U;
+            uint32_t col = (i0 + threadIdx.x * 8U) % 64U;
+            vec_memcpy(local,
+                       tileA + shared * (mrow * 64U) + __anf02 * 64U +
+                       shared * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sA[row * 64U + col + k] = local[k];
+        }
         half *tileB = gB;
-        uint32_t i = threadIdx.x;
-        for (; i < 4096U; i += 512U)
-            sB[i] =
-                tileB[(__anf01 * 64U + i / 64U) * cols + mcol * 64U + i % 64U];
+        uint32_t i = 0U;
+        for (; i < 4096U; i += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i + threadIdx.x * 8U) / 64U;
+            uint32_t col = (i + threadIdx.x * 8U) % 64U;
+            vec_memcpy(local,
+                       tileB + cols * (__anf02 * 64U) + mcol * 64U +
+                       cols * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sB[row * 64U + col + k] = local[k];
+        }
         __syncthreads();
         uint32_t dotIdx = 0U;
         for (; dotIdx < 4U; dotIdx++) {
-            uint32_t __anf04 = dotIdx;
             uint32_t __anf05 = dotIdx;
+            uint32_t __anf06 = dotIdx;
             half *b_tile = sB;
             wmma::load_matrix_sync(aFrag,
                                    sA + 64U * (threadIdx.x / 32U / 4U * 16U) +
-                                   __anf04 * 16U, 64U);
+                                   __anf05 * 16U, 64U);
             wmma::load_matrix_sync(bFrag,
-                                   b_tile + 64U * (__anf05 * 16U) +
+                                   b_tile + 64U * (__anf06 * 16U) +
                                    threadIdx.x / 32U % 4U * 16U, 64U);
             wmma::mma_sync(accumFrag, aFrag, bFrag, accumFrag);
         }
@@ -479,10 +593,11 @@ Kuiper_GEMM_TensorCore_g_gemm_f16_f16_64x64x64_16x16x16(uint32_t rows,
     KPR_GUARD(shared % 64U == 0U);
     KPR_GUARD(cols % 64U == 0U);
     uint32_t nblk = rows / 64U * (cols / 64U);
+    KPR_ASSERT(nblk <= 2097152U);
     KPR_SHMEM_FITS(16384U);
     MUST(cudaFuncSetAttribute
          (__hoisted_5, cudaFuncAttributeMaxDynamicSharedMemorySize, 16384U));
-    KPR_KCALL(__hoisted_5, nblk, 512U, 16384U, shared, cols, gA, gB, gC);
+    KPR_KCALL(__hoisted_5, nblk, 512U, 16384U, shared, cols, gA, gB, gC, 512U);
     MUST(cudaDeviceSynchronize());
 }
 
@@ -490,8 +605,9 @@ __global__
 /**
   hoisted when extracting g_gemm_f16_f16_64x64x64_32x8x16
 */
-static void __hoisted_6(uint32_t shared, uint32_t cols, half *gA, half *gB,
-                        half *gC)
+static void
+__hoisted_6(uint32_t shared, uint32_t cols, half *gA, half *gB, half *gC,
+            uint32_t nthr)
 {
     half *sA = (half *) KPR_SHMEM_AT(0U);
     half *sB = (half *) KPR_SHMEM_AT(8192U);
@@ -516,29 +632,46 @@ static void __hoisted_6(uint32_t shared, uint32_t cols, half *gA, half *gB,
     uint32_t bkIdx = 0U;
     for (; bkIdx < num_k_tiles; bkIdx++) {
         __syncthreads();
-        uint32_t __anf01 = bkIdx;
+        uint32_t __anf02 = bkIdx;
         half *tileA = gA;
-        uint32_t i0 = threadIdx.x;
-        for (; i0 < 4096U; i0 += 512U)
-            sA[i0] =
-                tileA[(mrow * 64U + i0 / 64U) * shared + __anf01 * 64U +
-                      i0 % 64U];
+        uint32_t i0 = 0U;
+        for (; i0 < 4096U; i0 += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i0 + threadIdx.x * 8U) / 64U;
+            uint32_t col = (i0 + threadIdx.x * 8U) % 64U;
+            vec_memcpy(local,
+                       tileA + shared * (mrow * 64U) + __anf02 * 64U +
+                       shared * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sA[row * 64U + col + k] = local[k];
+        }
         half *tileB = gB;
-        uint32_t i = threadIdx.x;
-        for (; i < 4096U; i += 512U)
-            sB[i] =
-                tileB[(__anf01 * 64U + i / 64U) * cols + mcol * 64U + i % 64U];
+        uint32_t i = 0U;
+        for (; i < 4096U; i += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i + threadIdx.x * 8U) / 64U;
+            uint32_t col = (i + threadIdx.x * 8U) % 64U;
+            vec_memcpy(local,
+                       tileB + cols * (__anf02 * 64U) + mcol * 64U +
+                       cols * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sB[row * 64U + col + k] = local[k];
+        }
         __syncthreads();
         uint32_t dotIdx = 0U;
         for (; dotIdx < 4U; dotIdx++) {
-            uint32_t __anf04 = dotIdx;
             uint32_t __anf05 = dotIdx;
+            uint32_t __anf06 = dotIdx;
             half *b_tile = sB;
             wmma::load_matrix_sync(aFrag,
                                    sA + 64U * (threadIdx.x / 32U / 8U * 32U) +
-                                   __anf04 * 16U, 64U);
+                                   __anf05 * 16U, 64U);
             wmma::load_matrix_sync(bFrag,
-                                   b_tile + 64U * (__anf05 * 16U) +
+                                   b_tile + 64U * (__anf06 * 16U) +
                                    threadIdx.x / 32U % 8U * 8U, 64U);
             wmma::mma_sync(accumFrag, aFrag, bFrag, accumFrag);
         }
@@ -562,10 +695,11 @@ Kuiper_GEMM_TensorCore_g_gemm_f16_f16_64x64x64_32x8x16(uint32_t rows,
     KPR_GUARD(shared % 64U == 0U);
     KPR_GUARD(cols % 64U == 0U);
     uint32_t nblk = rows / 64U * (cols / 64U);
+    KPR_ASSERT(nblk <= 2097152U);
     KPR_SHMEM_FITS(16384U);
     MUST(cudaFuncSetAttribute
          (__hoisted_6, cudaFuncAttributeMaxDynamicSharedMemorySize, 16384U));
-    KPR_KCALL(__hoisted_6, nblk, 512U, 16384U, shared, cols, gA, gB, gC);
+    KPR_KCALL(__hoisted_6, nblk, 512U, 16384U, shared, cols, gA, gB, gC, 512U);
     MUST(cudaDeviceSynchronize());
 }
 
@@ -573,8 +707,9 @@ __global__
 /**
   hoisted when extracting g_gemm_f16_f16_64x64x64_8x32x16
 */
-static void __hoisted_7(uint32_t shared, uint32_t cols, half *gA, half *gB,
-                        half *gC)
+static void
+__hoisted_7(uint32_t shared, uint32_t cols, half *gA, half *gB, half *gC,
+            uint32_t nthr)
 {
     half *sA = (half *) KPR_SHMEM_AT(0U);
     half *sB = (half *) KPR_SHMEM_AT(8192U);
@@ -599,29 +734,46 @@ static void __hoisted_7(uint32_t shared, uint32_t cols, half *gA, half *gB,
     uint32_t bkIdx = 0U;
     for (; bkIdx < num_k_tiles; bkIdx++) {
         __syncthreads();
-        uint32_t __anf01 = bkIdx;
+        uint32_t __anf02 = bkIdx;
         half *tileA = gA;
-        uint32_t i0 = threadIdx.x;
-        for (; i0 < 4096U; i0 += 512U)
-            sA[i0] =
-                tileA[(mrow * 64U + i0 / 64U) * shared + __anf01 * 64U +
-                      i0 % 64U];
+        uint32_t i0 = 0U;
+        for (; i0 < 4096U; i0 += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i0 + threadIdx.x * 8U) / 64U;
+            uint32_t col = (i0 + threadIdx.x * 8U) % 64U;
+            vec_memcpy(local,
+                       tileA + shared * (mrow * 64U) + __anf02 * 64U +
+                       shared * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sA[row * 64U + col + k] = local[k];
+        }
         half *tileB = gB;
-        uint32_t i = threadIdx.x;
-        for (; i < 4096U; i += 512U)
-            sB[i] =
-                tileB[(__anf01 * 64U + i / 64U) * cols + mcol * 64U + i % 64U];
+        uint32_t i = 0U;
+        for (; i < 4096U; i += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i + threadIdx.x * 8U) / 64U;
+            uint32_t col = (i + threadIdx.x * 8U) % 64U;
+            vec_memcpy(local,
+                       tileB + cols * (__anf02 * 64U) + mcol * 64U +
+                       cols * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sB[row * 64U + col + k] = local[k];
+        }
         __syncthreads();
         uint32_t dotIdx = 0U;
         for (; dotIdx < 4U; dotIdx++) {
-            uint32_t __anf04 = dotIdx;
             uint32_t __anf05 = dotIdx;
+            uint32_t __anf06 = dotIdx;
             half *b_tile = sB;
             wmma::load_matrix_sync(aFrag,
                                    sA + 64U * (threadIdx.x / 32U / 2U * 8U) +
-                                   __anf04 * 16U, 64U);
+                                   __anf05 * 16U, 64U);
             wmma::load_matrix_sync(bFrag,
-                                   b_tile + 64U * (__anf05 * 16U) +
+                                   b_tile + 64U * (__anf06 * 16U) +
                                    threadIdx.x / 32U % 2U * 32U, 64U);
             wmma::mma_sync(accumFrag, aFrag, bFrag, accumFrag);
         }
@@ -645,10 +797,11 @@ Kuiper_GEMM_TensorCore_g_gemm_f16_f16_64x64x64_8x32x16(uint32_t rows,
     KPR_GUARD(shared % 64U == 0U);
     KPR_GUARD(cols % 64U == 0U);
     uint32_t nblk = rows / 64U * (cols / 64U);
+    KPR_ASSERT(nblk <= 2097152U);
     KPR_SHMEM_FITS(16384U);
     MUST(cudaFuncSetAttribute
          (__hoisted_7, cudaFuncAttributeMaxDynamicSharedMemorySize, 16384U));
-    KPR_KCALL(__hoisted_7, nblk, 512U, 16384U, shared, cols, gA, gB, gC);
+    KPR_KCALL(__hoisted_7, nblk, 512U, 16384U, shared, cols, gA, gB, gC, 512U);
     MUST(cudaDeviceSynchronize());
 }
 
@@ -656,8 +809,9 @@ __global__
 /**
   hoisted when extracting g_gemm_f16_f16_32x32x32_16x16x16
 */
-static void __hoisted_8(uint32_t shared, uint32_t cols, half *gA, half *gB,
-                        half *gC)
+static void
+__hoisted_8(uint32_t shared, uint32_t cols, half *gA, half *gB, half *gC,
+            uint32_t nthr)
 {
     half *sA = (half *) KPR_SHMEM_AT(0U);
     half *sB = (half *) KPR_SHMEM_AT(2048U);
@@ -682,29 +836,46 @@ static void __hoisted_8(uint32_t shared, uint32_t cols, half *gA, half *gB,
     uint32_t bkIdx = 0U;
     for (; bkIdx < num_k_tiles; bkIdx++) {
         __syncthreads();
-        uint32_t __anf01 = bkIdx;
+        uint32_t __anf02 = bkIdx;
         half *tileA = gA;
-        uint32_t i0 = threadIdx.x;
-        for (; i0 < 1024U; i0 += 128U)
-            sA[i0] =
-                tileA[(mrow * 32U + i0 / 32U) * shared + __anf01 * 32U +
-                      i0 % 32U];
+        uint32_t i0 = 0U;
+        for (; i0 < 1024U; i0 += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i0 + threadIdx.x * 8U) / 32U;
+            uint32_t col = (i0 + threadIdx.x * 8U) % 32U;
+            vec_memcpy(local,
+                       tileA + shared * (mrow * 32U) + __anf02 * 32U +
+                       shared * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sA[row * 32U + col + k] = local[k];
+        }
         half *tileB = gB;
-        uint32_t i = threadIdx.x;
-        for (; i < 1024U; i += 128U)
-            sB[i] =
-                tileB[(__anf01 * 32U + i / 32U) * cols + mcol * 32U + i % 32U];
+        uint32_t i = 0U;
+        for (; i < 1024U; i += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i + threadIdx.x * 8U) / 32U;
+            uint32_t col = (i + threadIdx.x * 8U) % 32U;
+            vec_memcpy(local,
+                       tileB + cols * (__anf02 * 32U) + mcol * 32U +
+                       cols * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sB[row * 32U + col + k] = local[k];
+        }
         __syncthreads();
         uint32_t dotIdx = 0U;
         for (; dotIdx < 2U; dotIdx++) {
-            uint32_t __anf04 = dotIdx;
             uint32_t __anf05 = dotIdx;
+            uint32_t __anf06 = dotIdx;
             half *b_tile = sB;
             wmma::load_matrix_sync(aFrag,
                                    sA + 32U * (threadIdx.x / 32U / 2U * 16U) +
-                                   __anf04 * 16U, 32U);
+                                   __anf05 * 16U, 32U);
             wmma::load_matrix_sync(bFrag,
-                                   b_tile + 32U * (__anf05 * 16U) +
+                                   b_tile + 32U * (__anf06 * 16U) +
                                    threadIdx.x / 32U % 2U * 16U, 32U);
             wmma::mma_sync(accumFrag, aFrag, bFrag, accumFrag);
         }
@@ -728,10 +899,11 @@ Kuiper_GEMM_TensorCore_g_gemm_f16_f16_32x32x32_16x16x16(uint32_t rows,
     KPR_GUARD(shared % 32U == 0U);
     KPR_GUARD(cols % 32U == 0U);
     uint32_t nblk = rows / 32U * (cols / 32U);
+    KPR_ASSERT(nblk <= 2097152U);
     KPR_SHMEM_FITS(4096U);
     MUST(cudaFuncSetAttribute
          (__hoisted_8, cudaFuncAttributeMaxDynamicSharedMemorySize, 4096U));
-    KPR_KCALL(__hoisted_8, nblk, 128U, 4096U, shared, cols, gA, gB, gC);
+    KPR_KCALL(__hoisted_8, nblk, 128U, 4096U, shared, cols, gA, gB, gC, 128U);
     MUST(cudaDeviceSynchronize());
 }
 
@@ -739,8 +911,9 @@ __global__
 /**
   hoisted when extracting g_gemm_f16_f16_16x16x16_16x16x16
 */
-static void __hoisted_9(uint32_t shared, uint32_t cols, half *gA, half *gB,
-                        half *gC)
+static void
+__hoisted_9(uint32_t shared, uint32_t cols, half *gA, half *gB, half *gC,
+            uint32_t nthr)
 {
     half *sA = (half *) KPR_SHMEM_AT(0U);
     half *sB = (half *) KPR_SHMEM_AT(512U);
@@ -764,28 +937,45 @@ static void __hoisted_9(uint32_t shared, uint32_t cols, half *gA, half *gB,
     uint32_t bkIdx = 0U;
     for (; bkIdx < num_k_tiles; bkIdx++) {
         __syncthreads();
-        uint32_t __anf01 = bkIdx;
+        uint32_t __anf02 = bkIdx;
         half *tileA = gA;
-        uint32_t i0 = threadIdx.x;
-        for (; i0 < 256U; i0 += 32U)
-            sA[i0] =
-                tileA[(mrow * 16U + i0 / 16U) * shared + __anf01 * 16U +
-                      i0 % 16U];
+        uint32_t i0 = 0U;
+        for (; i0 < 256U; i0 += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i0 + threadIdx.x * 8U) / 16U;
+            uint32_t col = (i0 + threadIdx.x * 8U) % 16U;
+            vec_memcpy(local,
+                       tileA + shared * (mrow * 16U) + __anf02 * 16U +
+                       shared * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sA[row * 16U + col + k] = local[k];
+        }
         half *tileB = gB;
-        uint32_t i = threadIdx.x;
-        for (; i < 256U; i += 32U)
-            sB[i] =
-                tileB[(__anf01 * 16U + i / 16U) * cols + mcol * 16U + i % 16U];
+        uint32_t i = 0U;
+        for (; i < 256U; i += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i + threadIdx.x * 8U) / 16U;
+            uint32_t col = (i + threadIdx.x * 8U) % 16U;
+            vec_memcpy(local,
+                       tileB + cols * (__anf02 * 16U) + mcol * 16U +
+                       cols * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sB[row * 16U + col + k] = local[k];
+        }
         __syncthreads();
         uint32_t dotIdx = 0U;
         for (; dotIdx < 1U; dotIdx++) {
-            uint32_t __anf04 = dotIdx;
             uint32_t __anf05 = dotIdx;
+            uint32_t __anf06 = dotIdx;
             half *b_tile = sB;
             wmma::load_matrix_sync(aFrag,
                                    sA + 16U * (threadIdx.x / 32U * 16U) +
-                                   __anf04 * 16U, 16U);
-            wmma::load_matrix_sync(bFrag, b_tile + 16U * (__anf05 * 16U), 16U);
+                                   __anf05 * 16U, 16U);
+            wmma::load_matrix_sync(bFrag, b_tile + 16U * (__anf06 * 16U), 16U);
             wmma::mma_sync(accumFrag, aFrag, bFrag, accumFrag);
         }
     }
@@ -807,10 +997,11 @@ Kuiper_GEMM_TensorCore_g_gemm_f16_f16_16x16x16_16x16x16(uint32_t rows,
     KPR_GUARD(shared % 16U == 0U);
     KPR_GUARD(cols % 16U == 0U);
     uint32_t nblk = rows / 16U * (cols / 16U);
+    KPR_ASSERT(nblk <= 2097152U);
     KPR_SHMEM_FITS(1024U);
     MUST(cudaFuncSetAttribute
          (__hoisted_9, cudaFuncAttributeMaxDynamicSharedMemorySize, 1024U));
-    KPR_KCALL(__hoisted_9, nblk, 32U, 1024U, shared, cols, gA, gB, gC);
+    KPR_KCALL(__hoisted_9, nblk, 32U, 1024U, shared, cols, gA, gB, gC, 32U);
     MUST(cudaDeviceSynchronize());
 }
 
@@ -818,8 +1009,9 @@ __global__
 /**
   hoisted when extracting g_gemm_f16_f32_32x32x32_16x16x16
 */
-static void __hoisted_10(uint32_t shared, uint32_t cols, half *gA, half *gB,
-                         float *gC)
+static void
+__hoisted_10(uint32_t shared, uint32_t cols, half *gA, half *gB, float *gC,
+             uint32_t nthr)
 {
     half *sA = (half *) KPR_SHMEM_AT(0U);
     half *sB = (half *) KPR_SHMEM_AT(2048U);
@@ -844,29 +1036,46 @@ static void __hoisted_10(uint32_t shared, uint32_t cols, half *gA, half *gB,
     uint32_t bkIdx = 0U;
     for (; bkIdx < num_k_tiles; bkIdx++) {
         __syncthreads();
-        uint32_t __anf01 = bkIdx;
+        uint32_t __anf02 = bkIdx;
         half *tileA = gA;
-        uint32_t i0 = threadIdx.x;
-        for (; i0 < 1024U; i0 += 128U)
-            sA[i0] =
-                tileA[(mrow * 32U + i0 / 32U) * shared + __anf01 * 32U +
-                      i0 % 32U];
+        uint32_t i0 = 0U;
+        for (; i0 < 1024U; i0 += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i0 + threadIdx.x * 8U) / 32U;
+            uint32_t col = (i0 + threadIdx.x * 8U) % 32U;
+            vec_memcpy(local,
+                       tileA + shared * (mrow * 32U) + __anf02 * 32U +
+                       shared * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sA[row * 32U + col + k] = local[k];
+        }
         half *tileB = gB;
-        uint32_t i = threadIdx.x;
-        for (; i < 1024U; i += 128U)
-            sB[i] =
-                tileB[(__anf01 * 32U + i / 32U) * cols + mcol * 32U + i % 32U];
+        uint32_t i = 0U;
+        for (; i < 1024U; i += nthr * 8U) {
+            half local[8U];
+            memset(local, 0U, 8U * sizeof(half));
+            uint32_t row = (i + threadIdx.x * 8U) / 32U;
+            uint32_t col = (i + threadIdx.x * 8U) % 32U;
+            vec_memcpy(local,
+                       tileB + cols * (__anf02 * 32U) + mcol * 32U +
+                       cols * row + col);
+            uint32_t k = 0U;
+            for (; k < 8U; k++)
+                sB[row * 32U + col + k] = local[k];
+        }
         __syncthreads();
         uint32_t dotIdx = 0U;
         for (; dotIdx < 2U; dotIdx++) {
-            uint32_t __anf04 = dotIdx;
             uint32_t __anf05 = dotIdx;
+            uint32_t __anf06 = dotIdx;
             half *b_tile = sB;
             wmma::load_matrix_sync(aFrag,
                                    sA + 32U * (threadIdx.x / 32U / 2U * 16U) +
-                                   __anf04 * 16U, 32U);
+                                   __anf05 * 16U, 32U);
             wmma::load_matrix_sync(bFrag,
-                                   b_tile + 32U * (__anf05 * 16U) +
+                                   b_tile + 32U * (__anf06 * 16U) +
                                    threadIdx.x / 32U % 2U * 16U, 32U);
             wmma::mma_sync(accumFrag, aFrag, bFrag, accumFrag);
         }
@@ -890,9 +1099,10 @@ Kuiper_GEMM_TensorCore_g_gemm_f16_f32_32x32x32_16x16x16(uint32_t rows,
     KPR_GUARD(shared % 32U == 0U);
     KPR_GUARD(cols % 32U == 0U);
     uint32_t nblk = rows / 32U * (cols / 32U);
+    KPR_ASSERT(nblk <= 2097152U);
     KPR_SHMEM_FITS(4096U);
     MUST(cudaFuncSetAttribute
          (__hoisted_10, cudaFuncAttributeMaxDynamicSharedMemorySize, 4096U));
-    KPR_KCALL(__hoisted_10, nblk, 128U, 4096U, shared, cols, gA, gB, gC);
+    KPR_KCALL(__hoisted_10, nblk, 128U, 4096U, shared, cols, gA, gB, gC, 128U);
     MUST(cudaDeviceSynchronize());
 }

--- a/extraction/ExtractKuiper.fst
+++ b/extraction/ExtractKuiper.fst
@@ -403,7 +403,7 @@ let kpr_translate_expr : translate_expr_t = fun env e ->
 
   (******** BARRIERS ********)
 
-  | "Kuiper.Barrier.barrier_wait", [], [ _unit; _n; _p; _q; _it; _tid ] ->
+  | "Kuiper.Barrier.barrier_wait", [], [ _unit; _n; _contract; _it; _tid ] ->
     EApp (EQualified ([], "__syncthreads"), [ EUnit ])
 
   (******** TENSOR CORE OPERATIONS, FRAGMENTS, ETC ********)

--- a/src/examples/Kuiper.DotProduct.Poly.fst
+++ b/src/examples/Kuiper.DotProduct.Poly.fst
@@ -108,15 +108,11 @@ fn block_setup
   ()
   norewrite
   requires
-    can_create_barrier m_size **
     (live ga1 ** live ga2 ** live gr)
   ensures
-    consumed_can_create_barrier **
     (forall+ (tid : natlt m_size). kpre m_size ga1 ga2 gr tid) **
     emp (* frame *)
 {
-  no_mk_barrier ();
-
   // Slicing the arrays
   (**)gpu_array_slice_1_underspec ga1;
   (**)gpu_array_slice_1_underspec ga2;

--- a/src/examples/Kuiper.ZeroKernel.fst
+++ b/src/examples/Kuiper.ZeroKernel.fst
@@ -17,10 +17,9 @@ fn kf
 ghost
 fn block_setup ()
   norewrite
-  requires can_create_barrier 0 ** emp
-  ensures  consumed_can_create_barrier ** (forall+ (tid : natlt 0). emp) ** emp
+  requires emp
+  ensures  (forall+ (tid : natlt 0). emp) ** emp
 {
-  no_mk_barrier ();
   forevery_emp_intro (natlt 0);
 }
 

--- a/src/lib/inst/gemm/Kuiper.GEMM.TensorCore.Inst.fst
+++ b/src/lib/inst/gemm/Kuiper.GEMM.TensorCore.Inst.fst
@@ -2,22 +2,25 @@ module Kuiper.GEMM.TensorCore.Inst
 #lang-pulse
 
 open Kuiper
-open Kuiper.Matrix
+open Kuiper.Array.Vectorized { has_vec_cpy, chunk }
 open Kuiper.EMatrix
+open Kuiper.Matrix
 open Kuiper.Matrix.Reprs
+open Kuiper.Poly.GEMM.TensorCore
 open Kuiper.TensorCore
 
 module SZ = Kuiper.SizeT
 
-open Kuiper.Poly.GEMM.TensorCore
-#set-options "--z3rlimit 20"
+#set-options "--z3rlimit 40"
 
 inline_for_extraction noextract
 fn specialize_gpu
   // specialize
   (et_ab et_c : Type0)
-  {| scalar et_ab, scalar et_c |}
+  {| scalar et_ab, has_vec_cpy et_ab, scalar et_c |}
   (bm bn bk : szp)
+  (#_ : squash (chunk et_ab /?+ bk))
+  (#_ : squash (chunk et_ab /?+ bn))
   (tm : szp{tm /? bm})
   (tn : szp{tn /? bn})
   (tk : szp{tk /? bk})
@@ -33,14 +36,16 @@ fn specialize_gpu
   (#_ : squash (bm/tm * bn/tn * warp_size <= max_threads))
   (#_ : squash (SZ.fits (bm*bk + bm/tm * bn/tn * warp_size)))
   (#_ : squash (SZ.fits (bk*bn + bm/tm * bn/tn * warp_size)))
-  (rA rB rC : mrepr)
-  {| ca : crepr rA, cB : crepr rB, cC : crepr rC |}
 
   // do not specialize
   (rows shared cols : szp)
-  (gA : gpu_matrix et_ab (rA rows shared) { is_global_matrix gA })
-  (gB : gpu_matrix et_ab (rB shared cols) { is_global_matrix gB })
+  (gA : gpu_matrix et_ab (row_major rows shared) { is_global_matrix gA })
+  (gB : gpu_matrix et_ab (row_major shared cols) { is_global_matrix gB })
   (gC : gpu_matrix et_c (row_major rows cols) { is_global_matrix gC })
+  (#_ : squash (aligned 16 (core gA)))
+  (#_ : squash (aligned 16 (core gB)))
+  (#_ : squash (chunk et_ab * ((bm/tm) * (bn/tn) * warp_sz) /?+ (bm * bk)))
+  (#_ : squash (chunk et_ab * ((bm/tm) * (bn/tn) * warp_sz) /?+ (bk * bn)))
   (#eA : ematrix et_ab rows shared)
   (#eB : ematrix et_ab shared cols)
   (#eC : ematrix et_c rows cols)
@@ -73,8 +78,24 @@ fn specialize_gpu
   dguard (shared %^ bk = 0sz);
   dguard (cols   %^ bn = 0sz);
 
+  lemma_divides_trans (chunk et_ab) bk shared;
+  assert pure (chunk et_ab /?+ shared);
+  assert pure (aligned_strided_row_major (chunk et_ab)
+                (Kuiper.Matrix.Reprs.strided_row_major_base #(SZ.v rows) #(SZ.v shared)));
+
+  lemma_divides_trans (chunk et_ab) bn cols;
+  assert pure (chunk et_ab /?+ cols);
+  assert pure (aligned_strided_row_major (chunk et_ab)
+                (Kuiper.Matrix.Reprs.strided_row_major_base #(SZ.v shared) #(SZ.v cols)));
+
   let nblk = rows/^bm *^ (cols/^bn);
   let nthr = bm/^tm *^ (bn/^tn) *^ warp_sz;
+
+  assert pure (rows/bm <= rows);
+  assert pure (cols/bn <= cols);
+  dassert (nblk <=^ SZ.uint_to_t 2097152); // Inlining max_blocks.. not great.
+  assert pure (nblk <= max_blocks);
+
   launch_sync (
     mk_kernel gA #eA gB #eB gC #_ #eC bm bn bk tm tn tk #fA #fB nblk nthr ()
   );

--- a/src/lib/inst/gemm/Kuiper.GEMM.TensorCore.Inst.fsti
+++ b/src/lib/inst/gemm/Kuiper.GEMM.TensorCore.Inst.fsti
@@ -1,7 +1,9 @@
 module Kuiper.GEMM.TensorCore.Inst
 
 #lang-pulse
+
 open Kuiper
+open Kuiper.Array.Vectorized { has_vec_cpy, chunk }
 open Kuiper.Matrix
 open Kuiper.EMatrix
 open Kuiper.Matrix.Reprs
@@ -15,8 +17,10 @@ inline_for_extraction noextract
 fn specialize_gpu
   // specialize
   (et_ab et_c : Type0)
-  {| scalar et_ab, scalar et_c |}
+  {| scalar et_ab, has_vec_cpy et_ab, scalar et_c |}
   (bm bn bk : szp)
+  (#_ : squash (chunk et_ab /?+ bk))
+  (#_ : squash (chunk et_ab /?+ bn))
   (tm : szp{tm /? bm})
   (tn : szp{tn /? bn})
   (tk : szp{tk /? bk})
@@ -32,14 +36,16 @@ fn specialize_gpu
   (#_ : squash (bm/tm * bn/tn * warp_size <= max_threads))
   (#_ : squash (SZ.fits (bm*bk + bm/tm * bn/tn * warp_size)))
   (#_ : squash (SZ.fits (bk*bn + bm/tm * bn/tn * warp_size)))
-  (rA rB rC : mrepr)
-  {| ca : crepr rA, cB : crepr rB, cC : crepr rC |}
 
   // do not specialize
   (rows shared cols : szp)
-  (gA : gpu_matrix et_ab (rA rows shared) { is_global_matrix gA })
-  (gB : gpu_matrix et_ab (rB shared cols) { is_global_matrix gB })
+  (gA : gpu_matrix et_ab (row_major rows shared) { is_global_matrix gA })
+  (gB : gpu_matrix et_ab (row_major shared cols) { is_global_matrix gB })
   (gC : gpu_matrix et_c (row_major rows cols) { is_global_matrix gC })
+  (#_ : squash (aligned 16 (core gA)))
+  (#_ : squash (aligned 16 (core gB)))
+  (#_ : squash (chunk et_ab * ((bm/tm) * (bn/tn) * warp_sz) /?+ (bm * bk)))
+  (#_ : squash (chunk et_ab * ((bm/tm) * (bn/tn) * warp_sz) /?+ (bk * bn)))
   (#eA : ematrix et_ab rows shared)
   (#eB : ematrix et_ab shared cols)
   (#eC : ematrix et_c rows cols)

--- a/src/lib/inst/gemm/Kuiper.GEMM.TensorCore.fst
+++ b/src/lib/inst/gemm/Kuiper.GEMM.TensorCore.fst
@@ -5,23 +5,23 @@ open Kuiper
 open Kuiper.Matrix.Reprs
 open Kuiper.GEMM.TensorCore.Inst
 
-let g_gemm_f16_f16_64x64x16_16x16x16 = specialize_gpu half half 64sz 64sz 16sz 16sz 16sz 16sz row_major row_major row_major
+let g_gemm_f16_f16_64x64x16_16x16x16 = specialize_gpu half half 64sz 64sz 16sz 16sz 16sz 16sz 
 
-let g_gemm_f16_f16_32x32x32_32x8x16 = specialize_gpu half half 32sz 32sz 32sz 32sz 8sz 16sz row_major row_major row_major
-let g_gemm_f16_f16_32x32x32_8x32x16 = specialize_gpu half half 32sz 32sz 32sz 8sz 32sz 16sz row_major row_major row_major
+let g_gemm_f16_f16_32x32x32_32x8x16 = specialize_gpu half half 32sz 32sz 32sz 32sz 8sz 16sz
+let g_gemm_f16_f16_32x32x32_8x32x16 = specialize_gpu half half 32sz 32sz 32sz 8sz 32sz 16sz
 
-let g_gemm_f16_f16_32x8x16_32x8x16 = specialize_gpu half half 32sz 8sz 16sz 32sz 8sz 16sz row_major row_major row_major
+let g_gemm_f16_f16_32x8x16_32x8x16 = specialize_gpu half half 32sz 8sz 16sz 32sz 8sz 16sz
 
-let g_gemm_f16_f16_8x32x16_8x32x16 = specialize_gpu half half 32sz 32sz 32sz 8sz 32sz 16sz row_major row_major row_major
+let g_gemm_f16_f16_8x32x16_8x32x16 = specialize_gpu half half 32sz 32sz 32sz 8sz 32sz 16sz
 
 // These instances are tested.
-let g_gemm_f16_f16_64x64x64_16x16x16 = specialize_gpu half half 64sz 64sz 64sz 16sz 16sz 16sz row_major row_major row_major
-let g_gemm_f16_f16_64x64x64_32x8x16 = specialize_gpu half half 64sz 64sz 64sz 32sz 8sz 16sz row_major row_major row_major
-let g_gemm_f16_f16_64x64x64_8x32x16 = specialize_gpu half half 64sz 64sz 64sz 8sz 32sz 16sz row_major row_major row_major
+let g_gemm_f16_f16_64x64x64_16x16x16 = specialize_gpu half half 64sz 64sz 64sz 16sz 16sz 16sz
+let g_gemm_f16_f16_64x64x64_32x8x16 = specialize_gpu half half 64sz 64sz 64sz 32sz 8sz 16sz
+let g_gemm_f16_f16_64x64x64_8x32x16 = specialize_gpu half half 64sz 64sz 64sz 8sz 32sz 16sz
 
-let g_gemm_f16_f16_32x32x32_16x16x16 = specialize_gpu half half 32sz 32sz 32sz 16sz 16sz 16sz row_major row_major row_major
+let g_gemm_f16_f16_32x32x32_16x16x16 = specialize_gpu half half 32sz 32sz 32sz 16sz 16sz 16sz
 
-let g_gemm_f16_f16_16x16x16_16x16x16 = specialize_gpu half half 16sz 16sz 16sz 16sz 16sz 16sz row_major row_major row_major
+let g_gemm_f16_f16_16x16x16_16x16x16 = specialize_gpu half half 16sz 16sz 16sz 16sz 16sz 16sz
 
 // mixed precision
-let g_gemm_f16_f32_32x32x32_16x16x16 = specialize_gpu half float 32sz 32sz 32sz 16sz 16sz 16sz row_major row_major row_major
+let g_gemm_f16_f32_32x32x32_16x16x16 = specialize_gpu half float 32sz 32sz 32sz 16sz 16sz 16sz

--- a/src/lib/kuiper/Kuiper.Barrier.RPM.fst
+++ b/src/lib/kuiper/Kuiper.Barrier.RPM.fst
@@ -8,39 +8,11 @@ open Kuiper.Base
 module B = Kuiper.Barrier
 open Kuiper.SizeT
 
-let mbarrier_tok
-  (n : nat)
-  (p : rpm_t n)
-  : slprop
-  =
-  (* Trade a row of p for a column of p. *)
-  B.barrier_tok #n
-    (row p)
-    (col p)
 
-instance mbarrier_tok_sendable
-  (n:nat)
-  (p : rpm_t n)
-: is_send_across block_of (mbarrier_tok n p)
-= solve
-
-ghost
-fn mk_mbarrier
-  (n: nat { 0 < n /\ n <= max_threads })
-  (p : rpm_t n)
-  requires can_create_barrier n
-  ensures  consumed_can_create_barrier
-  ensures forall+ (i : natlt n). mbarrier_tok n p ** B.barrier_state 0
-{
-  B.mk_barrier n (row p) (col p) fn it {
-    (* very nice. *)
-    forevery_commute (p it);
-  };
-  (* Need to intro an exists in every component of the bigstar. *)
-  forevery_map
-    (fun (i: natlt n) -> B.barrier_tok #n (row p) (col p) ** B.barrier_state 0)
-    (fun (i: natlt n) -> mbarrier_tok n p ** B.barrier_state 0)
-    fn i { fold (mbarrier_tok n p) };
+(* Cool. *)
+fn mbarrier_transform (#n:nat) (p:rpm_t n)
+: B.barrier_transform #n (mbarrier_contract p) = it {
+  forevery_commute (p it);
 }
 
 inline_for_extraction noextract
@@ -56,6 +28,8 @@ fn mbarrier_wait
   ensures  B.barrier_state (it+1) ** col p it tid
 {
   unfold mbarrier_tok;
+  rewrite row p it tid as (mbarrier_contract p).B.rin it tid;
   B.barrier_wait ();
+  rewrite (mbarrier_contract p).B.rout it tid as col p it tid;
   fold mbarrier_tok;
 }

--- a/src/lib/kuiper/Kuiper.Barrier.RPM.fsti
+++ b/src/lib/kuiper/Kuiper.Barrier.RPM.fsti
@@ -29,24 +29,21 @@ let col
   : slprop =
   forall+ (i: natlt n). p it i j
 
+(* Trade a row of p for a column of p. *)
+let mbarrier_contract (#n:nat) (p : rpm_t n) : B.contract n = {
+  B.rin = row p;
+  B.rout = col p;
+}
+
 [@@no_mkeys]
-val mbarrier_tok
-  (n:nat)
-  (p : rpm_t n)
-  : slprop
+unfold
+let mbarrier_tok (n : nat) (p : rpm_t n) : slprop =
+  B.barrier_tok #n (mbarrier_contract p)
 
-instance val mbarrier_tok_sendable
-  (n:nat)
+val mbarrier_transform 
+  (#n : nat)
   (p : rpm_t n)
-: is_send_across block_of (mbarrier_tok n p)
-
-ghost
-fn mk_mbarrier
-  (n: nat { 0 < n /\ n <= max_threads })
-  (p : rpm_t n)
-  requires can_create_barrier n
-  ensures  consumed_can_create_barrier
-  ensures forall+ (i : natlt n). mbarrier_tok n p ** B.barrier_state 0
+  : B.barrier_transform #n (mbarrier_contract p)
 
 // NB: reusing the same barrier_state token
 inline_for_extraction noextract

--- a/src/lib/kuiper/Kuiper.Barrier.fsti
+++ b/src/lib/kuiper/Kuiper.Barrier.fsti
@@ -18,11 +18,26 @@ type barrier_side (n:nat) =
   tid : natlt n ->
   slprop
 
-type barrier_transform (#n:nat) (p q : barrier_side n) =
+[@@erasable]
+noeq
+type contract (n:nat) = {
+  rin  : barrier_side n;
+  rout : barrier_side n;
+}
+
+let empty_contract (n:nat) : contract n = {
+  rin  = (fun _it _tid -> emp);
+  rout = (fun _it _tid -> emp);
+}
+
+type barrier_transform (#n:nat) (c : contract n) =
   it:nat ->
   stt_ghost unit emp_inames
-           (requires forall+ (i:natlt n). p it i)
-           (ensures  fun _ -> forall+ (i:natlt n). q it i)
+           (requires forall+ (i:natlt n). c.rin it i)
+           (ensures  fun _ -> forall+ (i:natlt n). c.rout it i)
+
+val empty_barrier_transform (n:nat)
+  : barrier_transform (empty_contract n)
 
 (* A token representing that there is a barrier in scope.
    This is a ghost token, and is not used at runtime. *)
@@ -30,34 +45,13 @@ type barrier_transform (#n:nat) (p q : barrier_side n) =
 (* A token representing that there is a barrier in scope with contract (p,q).
 This does not change as we wait on the barrier. *)
 [@@no_mkeys]
-val barrier_tok (#n:nat) (p q : barrier_side n) : slprop
+val barrier_tok (#n:nat) (c : contract n) : slprop
 
 (* A token that we are at iteration `it` of the current barrier. *)
 [@@no_mkeys]
 val barrier_state (it : nat) : slprop
 
-instance val barrier_tok_sendable
-  (n:nat)
-  (p q : barrier_side n)
-: is_send_across block_of (barrier_tok #n p q)
-
-instance val barrier_state_sendable
-  (it : nat)
-: is_send_across block_of (barrier_state it)
-
-(* Creating a barrier for n threads. Note how this is a
-   ghost function!. The 'pf' argument is a proof, once and
-   for all, that the resource passing in each barrier_wait is
-   correct, since it shows how all of the p's give all of the
-   q's at each iteration. *)
-ghost
-fn mk_barrier
-  (n: nat)
-  (p q : barrier_side n)
-  (pf : barrier_transform p q)
-  requires can_create_barrier n
-  ensures  consumed_can_create_barrier
-  ensures  forall+ (i:natlt n). barrier_tok p q ** barrier_state 0
+(* Note: none of the tokens above are sendable at all. *)
 
 (* Wait on the barrier. This function blocks until all threads call it
    simultaneously. Each thread provides the current p
@@ -65,10 +59,10 @@ fn mk_barrier
 fn barrier_wait
   ()
   (#n : erased nat)
-  (#p #q : barrier_side n)
+  (#c : contract n)
   (#it : erased nat)
   (#tid : enatlt n)
-  preserves barrier_tok p q
+  preserves barrier_tok c
   preserves thread_id n tid
-  requires barrier_state it     ** p it tid
-  ensures  barrier_state (it+1) ** q it tid
+  requires barrier_state it     ** c.rin it tid
+  ensures  barrier_state (it+1) ** c.rout it tid

--- a/src/lib/kuiper/Kuiper.Base.fsti
+++ b/src/lib/kuiper/Kuiper.Base.fsti
@@ -86,25 +86,6 @@ val is_cpu_loc_single_process (l0 l1:loc_id)
 (* Token for being in CPU code *)
 let cpu : slprop = exists* l. loc l ** pure (is_cpu_loc l)
 
-(* Token allowing to create a barrier for n threads. Only
-   available while in the block_setup of a kernel. *)
-[@@no_mkeys]
-val can_create_barrier (nthr : nat) : slprop
-
-(* Token marking we have in fact created a barrier, or ditched the
-   token.  This makes sure the token is not stashed away somewhere. *)
-[@@no_mkeys]
-val consumed_can_create_barrier : slprop
-
-(* A function that can be called to consume the token
-   without actually creating a barrier. We could also
-   define consumed_can_create_barrier as a trivial
-   barrier token. *)
-ghost
-fn no_mk_barrier (#n:nat) ()
-  requires can_create_barrier n
-  ensures  consumed_can_create_barrier
-
 (* This should be 2^31-1, or 2^30. We constrain this more than normal due to our
 hack about interpreting size_t as uint32_t in karamel (see Kuiper.SizeT). When
 that is gone, this should be increased. *)

--- a/src/lib/kuiper/Kuiper.Kernel.Casts.fst
+++ b/src/lib/kuiper/Kuiper.Kernel.Casts.fst
@@ -19,11 +19,9 @@ fn kmn_as_kfull_block_setup
   ()
   norewrite
   requires
-    can_create_barrier k.nthr **
     live_c_shmems sh **
     k.block_pre bid
   ensures
-    consumed_can_create_barrier **
     (forall+ (i : natlt k.nthr). k.kpre bid i) **
     (k.block_frame bid **
       live_c_shmems sh)
@@ -51,6 +49,49 @@ fn kmn_as_kfull_block_teardown
   f bid;
 }
 
+inline_for_extraction noextract
+fn adapt_kmn_kf
+  (#nblk #nthr : erased nat)
+  #kpre
+  #kpost
+  (f : (
+    bid : szlt nblk ->
+    tid : szlt nthr ->
+    unit ->
+    stt unit
+      (requires
+         gpu **
+         kpre bid tid **
+         thread_id nthr tid **
+         block_id nblk bid)
+      (ensures fun _ ->
+         gpu **
+         kpost bid tid **
+         thread_id nthr tid **
+         block_id nblk bid)
+  ))
+  (_ : c_shmems [])
+  (bid : szlt nblk)
+  (tid : szlt nthr)
+  ()
+  requires
+    gpu **
+    kpre bid tid **
+    thread_id nthr tid **
+    block_id nblk bid **
+    B.barrier_tok (B.empty_contract nthr) **
+    B.barrier_state 0
+  ensures
+    gpu **
+    kpost bid tid **
+    thread_id nthr tid **
+    block_id nblk bid
+{
+  drop_ (B.barrier_tok _);
+  drop_ (B.barrier_state _);
+  f bid tid ();
+}
+
 [@@coercion]
 inline_for_extraction noextract
 let kmn_as_kfull
@@ -61,6 +102,9 @@ let kmn_as_kfull
   {
   nblk=k.nblk;
   nthr=k.nthr;
+
+  barrier_contract = (fun _bid _ptrs -> B.empty_contract k.nthr);
+  barrier_ok       = (fun _bid _ptrs -> B.empty_barrier_transform k.nthr);
 
   shmems_desc = [];
 
@@ -79,7 +123,7 @@ let kmn_as_kfull
   block_setup = kmn_as_kfull_block_setup k;
   block_teardown = kmn_as_kfull_block_teardown k;
 
-  f = (fun _ear -> f);
+  f = adapt_kmn_kf k.f;
 
   block_pre_sendable;
   block_post_sendable;
@@ -224,23 +268,6 @@ fn pad_teardown
   teardown ();
 }
 
-ghost
-fn kn_as_kmn_block_setup (#full_pre #full_post : slprop)
-  (k : kernel_desc_n full_pre full_post)
-  (bid : natlt (sdivup k.nthr 1024sz))
-  norewrite
-  requires
-    can_create_barrier 1024 **
-    (forall+ (tid : natlt 1024sz). pad_kn k k.kpre bid tid)
-  ensures
-    consumed_can_create_barrier **
-    (forall+ (tid : natlt 1024sz). pad_kn k k.kpre bid tid) **
-    emp
-{
-  no_mk_barrier ();
-}
-
-
 inline_for_extraction noextract
 let kn_as_kmn (#full_pre #full_post : slprop)
   (k : kernel_desc_n full_pre full_post)
@@ -264,7 +291,7 @@ let kn_as_kmn (#full_pre #full_post : slprop)
   kpre  = pad_kn k k.kpre;
   kpost = pad_kn k k.kpost;
 
-  block_setup    = kn_as_kmn_block_setup k;
+  block_setup    = (fun bid -> Kuiper.Frame.emp_intro_r ());
   block_teardown = (fun bid -> Kuiper.Frame.emp_elim_r ());
 
   f = adapt_kn_as_kmn k #();
@@ -288,14 +315,11 @@ fn km1_as_kmn_block_setup
   (bid: natlt k.nblk)
   norewrite
   requires
-    can_create_barrier 1sz **
     k.kpre bid
   ensures
-    consumed_can_create_barrier **
     (forall+ (i : natlt 1sz). k.kpre bid) **
     emp
 {
-  no_mk_barrier ();
   forevery_singleton_intro #(natlt 1sz) (fun _ -> k.kpre bid);
 }
 
@@ -431,14 +455,11 @@ fn k11_as_k1n_block_setup
   ()
   norewrite
   requires
-    can_create_barrier 1sz **
     full_pre
   ensures
-    consumed_can_create_barrier **
     (forall+ (bid: natlt 1sz). full_pre) **
     emp
 {
-  no_mk_barrier ();
   forevery_singleton_intro #(natlt 1sz) (fun _ -> full_pre);
 }
 
@@ -506,3 +527,69 @@ let k11_as_kfull
   (k : kernel_desc_1_1 full_pre full_post)
      : kernel_desc     full_pre full_post
   = k |> k11_as_k1n |> k1n_as_kmn |> kmn_as_kfull
+
+inline_for_extraction noextract
+fn adapt_k1nb_kf
+  (#full_pre #full_post : slprop)
+  (k : kernel_desc_1_n_barr full_pre full_post)
+  (_ptrs : c_shmems [])
+  (_bid : szlt 1sz)
+  (tid : szlt k.nthr)
+  ()
+  requires
+    gpu **
+    k.kpre tid **
+    thread_id k.nthr tid **
+    block_id 1sz _bid **
+    B.barrier_tok k.barrier_contract **
+    B.barrier_state 0
+  ensures
+    gpu **
+    k.kpost tid **
+    thread_id k.nthr tid **
+    block_id 1sz _bid
+{
+  let f = k.f;
+  f tid ();
+  ()
+}
+
+[@@coercion]
+inline_for_extraction noextract
+let k1nb_as_kfull
+  (#full_pre #full_post : slprop)
+  (k : kernel_desc_1_n_barr full_pre full_post)
+     : kernel_desc     full_pre full_post
+  = let open k <: kernel_desc_1_n_barr full_pre full_post in
+    [@@inline_let] let _ : is_send_across gpu_of full_pre = k.full_pre_sendable in
+    [@@inline_let] let _ : is_send_across gpu_of full_post = k.full_post_sendable in
+    {
+    nblk = 1sz;
+    nthr = k.nthr;
+
+    shmems_desc = [];
+
+    barrier_contract = (fun _bid _ptrs -> k.barrier_contract);
+    barrier_ok       = (fun _bid _ptrs -> k.barrier_ok);
+
+    frame = emp;
+
+    block_pre   = (fun _ -> full_pre);
+    block_post  = (fun _ -> full_post);
+    block_frame = (fun _ptrs _bid -> k.frame);
+
+    setup    = magic();
+    teardown = magic();
+
+    kpre  = (fun _ptrs _bid -> k.kpre);
+    kpost = (fun _ptrs _bid -> k.kpost);
+
+    block_setup = magic(); // (fun _ -> k.block_setup ());
+    block_teardown = magic(); // (fun _ -> k.block_teardown ());
+
+    f = adapt_k1nb_kf k;
+    block_pre_sendable = (fun _ -> k.full_pre_sendable);
+    block_post_sendable = (fun _ -> k.full_post_sendable);
+    kpre_sendable = magic();
+    kpost_sendable = magic();
+  } <: kernel_desc full_pre full_post

--- a/src/lib/kuiper/Kuiper.Kernel.Casts.fsti
+++ b/src/lib/kuiper/Kuiper.Kernel.Casts.fsti
@@ -8,13 +8,14 @@ open Kuiper.Base
 open Kuiper.Kernel.Desc
 open Kuiper.SizeT
 module SZ = Kuiper.SizeT
+module B = Kuiper.Barrier
 
 (* PLEASE NOTE: the types here are very order sensitive. Make
 sure to keep uniformity if you change anything. For instance,
 all the frames are on the right most component of a star
 so they can be easily intro/elim'd when empty. *)
 
-(* MxN, no shared memory *)
+(* MxN, no shared memory, no barrier *)
 noeq
 inline_for_extraction noextract
 type kernel_desc_m_n (full_pre : slprop) (full_post : slprop) = {
@@ -53,10 +54,8 @@ type kernel_desc_m_n (full_pre : slprop) (full_post : slprop) = {
     (bid: natlt nblk) ->
     stt_ghost unit emp_inames
       (requires
-        can_create_barrier nthr **
         block_pre bid)
       (ensures fun _ ->
-        consumed_can_create_barrier **
         (forall+ (i : natlt nthr). kpre bid i) **
         block_frame bid)
   );
@@ -98,7 +97,7 @@ type kernel_desc_m_n (full_pre : slprop) (full_post : slprop) = {
 
 }
 
-(* N independent jobs, no shared memory, to be broken up
+(* N independent jobs, no shared memory, no barrier, to be broken up
 into blocks/threads as needed. *)
 noeq
 inline_for_extraction noextract
@@ -148,7 +147,7 @@ type kernel_desc_n (full_pre : slprop) (full_post : slprop) = {
 }
 
 
-(* 1xN, no shared memory *)
+(* 1xN, no shared memory, no barrier *)
 noeq
 inline_for_extraction noextract
 type kernel_desc_1_n (full_pre : slprop) (full_post : slprop) = {
@@ -163,10 +162,8 @@ type kernel_desc_1_n (full_pre : slprop) (full_post : slprop) = {
     unit ->
     stt_ghost unit emp_inames
       (requires
-        can_create_barrier nthr **
         full_pre)
       (ensures fun _ ->
-        consumed_can_create_barrier **
         (forall+ (tid : natlt nthr). kpre tid) **
         frame)
   );
@@ -201,7 +198,64 @@ type kernel_desc_1_n (full_pre : slprop) (full_post : slprop) = {
   kpost_sendable: (j:natlt nthr -> is_send_across block_of (kpost j));
 }
 
-(* Mx1, no shared memory *)
+(* 1xN, no shared memory, but with a barrier *)
+noeq
+inline_for_extraction noextract
+type kernel_desc_1_n_barr (full_pre : slprop) (full_post : slprop) = {
+  nthr : (x : SZ.t { x <= max_threads });
+
+  frame : slprop;
+
+  kpre  : (tid : natlt nthr) -> slprop;
+  kpost : (tid : natlt nthr) -> slprop;
+
+  (* Note, does not depend on bid (only one) or shmem ptrs (there are none) *)
+  barrier_contract : B.contract nthr;
+  barrier_ok       : B.barrier_transform barrier_contract;
+
+  block_setup : (
+    unit ->
+    stt_ghost unit emp_inames
+      (requires
+        full_pre)
+      (ensures fun _ ->
+        (forall+ (tid : natlt nthr). kpre tid) **
+        frame)
+  );
+
+  block_teardown : (
+    unit ->
+    stt_ghost unit emp_inames
+      (requires
+        (forall+ (tid : natlt nthr). kpost tid) **
+        frame)
+      (ensures fun _ ->
+        full_post)
+  );
+
+  f : (
+    tid : szlt nthr ->
+    unit ->
+    stt unit
+      (requires
+         gpu **
+         kpre tid **
+         thread_id nthr tid **
+         B.barrier_tok barrier_contract **
+         B.barrier_state 0)
+      (ensures fun _ ->
+         gpu **
+         kpost tid **
+         thread_id nthr tid)
+  );
+
+  full_pre_sendable: is_send_across gpu_of full_pre;
+  full_post_sendable: is_send_across gpu_of full_post;
+  kpre_sendable: (j:natlt nthr -> is_send_across block_of (kpre j));
+  kpost_sendable: (j:natlt nthr -> is_send_across block_of (kpost j));
+}
+
+(* Mx1, no shared memory, no barrier *)
 noeq
 inline_for_extraction noextract
 type kernel_desc_m_1 (full_pre : slprop) (full_post : slprop) = {
@@ -250,7 +304,7 @@ type kernel_desc_m_1 (full_pre : slprop) (full_post : slprop) = {
   kpost_sendable: (j:natlt nblk -> is_send_across gpu_of (kpost j));
 }
 
-(* 1x1, no shared memory *)
+(* 1x1, no shared memory, no barrier *)
 noeq
 inline_for_extraction noextract
 type kernel_desc_1_1 (full_pre : slprop) (full_post : slprop) = {
@@ -320,4 +374,11 @@ inline_for_extraction noextract
 val k11_as_kfull
   (#full_pre #full_post : slprop)
   (k : kernel_desc_1_1 full_pre full_post)
+     : kernel_desc     full_pre full_post
+
+[@@coercion]
+inline_for_extraction noextract
+val k1nb_as_kfull
+  (#full_pre #full_post : slprop)
+  (k : kernel_desc_1_n_barr full_pre full_post)
      : kernel_desc     full_pre full_post

--- a/src/lib/kuiper/Kuiper.Kernel.Desc.fst
+++ b/src/lib/kuiper/Kuiper.Kernel.Desc.fst
@@ -10,6 +10,7 @@ open Kuiper.Base
 open Kuiper.SizeT
 open Kuiper.SHMem
 module SZ = Kuiper.SizeT
+module B = Kuiper.Barrier
 
 (* A full kernel description, in its most general form. There are
 simpler version in the Kuiper.Kernel.Casts module. *)
@@ -33,6 +34,10 @@ type kernel_desc (full_pre full_post : slprop) = {
     natlt nthr ->
     slprop;
 
+  (* Barrier contract + proof, for every block. *)
+  barrier_contract : bid:natlt nblk -> ptrs:c_shmems shmems_desc -> B.contract nthr;
+  barrier_ok       : bid:natlt nblk -> ptrs:c_shmems shmems_desc -> B.barrier_transform (barrier_contract bid ptrs);
+
   f : (
     sh : c_shmems shmems_desc ->
     bid : szlt nblk ->
@@ -43,7 +48,13 @@ type kernel_desc (full_pre full_post : slprop) = {
          gpu **
          kpre sh bid tid **
          thread_id nthr tid **
-         block_id nblk bid)
+         block_id nblk bid **
+         B.barrier_tok (barrier_contract bid sh) **
+         B.barrier_state 0
+         )
+      // Note: can drop barrier_tok (ok...) and barrier_state (maybe not ok,
+      // would maybe be nice to have a barrier_count for each block and enforce
+      // it here?)
       (ensures fun _ ->
          gpu **
          kpost sh bid tid **
@@ -83,11 +94,9 @@ type kernel_desc (full_pre full_post : slprop) = {
     unit ->
     stt_ghost unit emp_inames
       (requires
-        can_create_barrier nthr **
         live_c_shmems sh **
         block_pre bid)
       (ensures fun _ ->
-        consumed_can_create_barrier **
         (forall+ (i : natlt nthr). kpre sh bid i) **
         block_frame sh bid)
   );

--- a/src/lib/kuiper/Kuiper.Kernel.Sync.fst
+++ b/src/lib/kuiper/Kuiper.Kernel.Sync.fst
@@ -123,6 +123,7 @@ ensures
         fold (block_id k.nblk bid);
         loc_dup tloc;
         fold gpu;
+  admit();
         Mkkernel_desc?.f k sh bid tid ();
         drop_ gpu; // from the loc_dup above
         drop_ (block_id _ _); // from the loc_dup above
@@ -153,14 +154,14 @@ ensures
   unfold (block_id k.nblk bid);
   let sh = alloc_c_shmems _ k.shmems_desc;
   fold (block_id k.nblk bid);
-  assume (can_create_barrier k.nthr);
+  admit();
+  // assume (can_create_barrier k.nthr);
   let _ : unit = Mkkernel_desc?.block_setup k sh bid ();
   run_block_threads k bid sh k.nthr;
   Mkkernel_desc?.block_teardown k sh bid ();
   unfold (block_id k.nblk bid);
   free_c_shmems _ _ sh;
   fold (block_id k.nblk bid);
-  drop_ consumed_can_create_barrier; // assume
 }
 
 noextract

--- a/src/lib/poly/Kuiper.Poly.DotProduct.fst
+++ b/src/lib/poly/Kuiper.Poly.DotProduct.fst
@@ -56,9 +56,7 @@ let kpre
   (tid : natlt lena)
   : slprop
   = gpu_pts_to_slice ga1 tid (tid + 1) seq![s1 @! tid] **
-    gpu_pts_to_slice ga2 tid (tid + 1) seq![s2 @! tid] **
-    mbarrier_tok lena (HR.barrier_matrix lena ga1 (pmul s1 s2) (rsmul vr1 vr2)) **
-    B.barrier_state 0
+    gpu_pts_to_slice ga2 tid (tid + 1) seq![s2 @! tid]
 
 (* ^ Note how the instantiation of the barrier states (pmul s1 s2) regarless
      of whatever is in sr. This is since the first thing the kernel will do is
@@ -76,8 +74,6 @@ let kpost
   (tid : natlt lena)
   : slprop
   = gpu_pts_to_slice ga2 tid (tid + 1) seq![s2 @! tid] **
-    mbarrier_tok lena (HR.barrier_matrix lena ga1 (pmul s1 s2) (rsmul vr1 vr2)) **
-    (exists* it. B.barrier_state it) **
     (if_ (tid = 0) (HR.gpu_pts_to_slice_sum ga1 0 lena (pmul s1 s2) (rsmul vr1 vr2)))
 
 inline_for_extraction noextract
@@ -93,7 +89,9 @@ fn kf
   requires
     gpu **
     kpre lena ga1 ga2 s1 s2 vr1 vr2 tid **
-    thread_id lena tid
+    thread_id lena tid **
+    B.barrier_tok (mbarrier_contract #lena (HR.barrier_matrix lena ga1 (pmul s1 s2) (rsmul vr1 vr2))) **
+    B.barrier_state 0
   ensures
     gpu **
     kpost lena ga1 ga2 s1 s2 vr1 vr2 tid **
@@ -131,24 +129,18 @@ fn setup
   (_: squash ( len s1 == SZ.v lena /\ len s2 == SZ.v lena ))
   norewrite
   requires
-    can_create_barrier lena **
-    (ga2 |-> s2 ** ga1 |-> s1)
+    ga2 |-> s2 ** ga1 |-> s1
   ensures
-    consumed_can_create_barrier **
     (forall+ (bid : natlt lena). kpre lena ga1 ga2 s1 s2 vr1 vr2 bid) **
     emp (* frame *)
 {
-  mk_mbarrier lena (HR.barrier_matrix lena ga1 (pmul s1 s2) (rsmul vr1 vr2));
   gpu_array_slice_1 ga2;
-  forevery_zip
-    (fun (i: natlt (v lena)) -> gpu_pts_to_slice ga2 i (i + 1) seq![Seq.Base.index s2 i]) _;
   gpu_array_slice_1 ga1;
   forevery_zip (fun (i: natlt (v lena)) -> gpu_pts_to_slice ga1 i (i + 1) seq![Seq.Base.index s1 i]) _;
   forevery_map
    (fun (i: natlt (v lena)) -> //too bad that you have to write this; inference should find it
       gpu_pts_to_slice ga1 i (i + 1) seq![Seq.Base.index s1 i] **
-      gpu_pts_to_slice ga2 i (i + 1) seq![Seq.Base.index s2 i] **
-      mbarrier_tok lena (HR.barrier_matrix lena ga1 (pmul s1 s2) (rsmul vr1 vr2)) ** B.barrier_state 0)
+      gpu_pts_to_slice ga2 i (i + 1) seq![Seq.Base.index s2 i])
    (kpre lena ga1 ga2 s1 s2 vr1 vr2) fn bid { fold kpre lena ga1 ga2 s1 s2 vr1 vr2 bid };
 }
 
@@ -176,20 +168,14 @@ fn teardown
   forevery_map (kpost lena ga1 ga2 s1 s2 vr1 vr2)
     (fun tid ->
       gpu_pts_to_slice ga2 tid (tid + 1) seq![s2 @! tid] **
-      mbarrier_tok lena (HR.barrier_matrix lena ga1 (pmul s1 s2) (rsmul vr1 vr2)) **
-      ((exists* it. B.barrier_state it) **
-       (if_ (tid = 0) (HR.gpu_pts_to_slice_sum ga1 0 lena (pmul s1 s2) (rsmul vr1 vr2)))))
+      (if_ (tid = 0) (HR.gpu_pts_to_slice_sum ga1 0 lena (pmul s1 s2) (rsmul vr1 vr2))))
     fn tid { unfold (kpost lena ga1 ga2 s1 s2 vr1 vr2 tid) };
   forevery_unzip _ _;
   gpu_array_unslice_1 ga2;
-  forevery_unzip _ _;
-  forevery_unzip _ _;
   forevery_extract #(natlt lena) 0
     (fun tid -> (if_ (tid = 0) (HR.gpu_pts_to_slice_sum ga1 0 lena (pmul s1 s2) (rsmul vr1 vr2))));
   if_elim_true _;
   drop_ (Pulse.Lib.Trade.trade _ _);
-  drop_ (forall+ (tid:natlt lena). exists* it. B.barrier_state it);
-  drop_ (forall+ (tid:natlt lena). _);
   unfold HR.gpu_pts_to_slice_sum ga1 0 lena (pmul s1 s2) (rsmul vr1 vr2);
 }
 
@@ -209,6 +195,9 @@ let dp_kernel
     nthr = lena;
     f = kf lena ga1 ga2 #s1 #s2;
 
+    barrier_contract = mbarrier_contract #lena (HR.barrier_matrix lena ga1 (pmul s1 s2) (rsmul vr1 vr2));
+    barrier_ok       = mbarrier_transform _;
+
     block_setup    = setup lena ga1 ga2 #s1 #s2;
     block_teardown = teardown lena ga1 ga2 #s1 #s2;
 
@@ -221,7 +210,7 @@ let dp_kernel
     kpre_sendable=solve;
     full_post_sendable=solve;
     full_pre_sendable=solve;
-  } <: kernel_desc_1_n _ _
+  } <: kernel_desc_1_n_barr _ _
 
 
 inline_for_extraction noextract

--- a/src/lib/poly/Kuiper.Poly.HReduce.fst
+++ b/src/lib/poly/Kuiper.Poly.HReduce.fst
@@ -139,9 +139,7 @@ let kpre
   (#_: squash (len s == lena))
   (tid : natlt lena)
   : slprop =
-    gpu_pts_to_slice a tid (tid +1) seq![s @! tid] **
-    mbarrier_tok lena (barrier_matrix lena a s vr) **
-    B.barrier_state 0
+    gpu_pts_to_slice a tid (tid +1) seq![s @! tid]
 
 unfold
 let kpost
@@ -153,9 +151,7 @@ let kpost
   (#_: squash (len s == lena))
   (tid : natlt lena)
   : slprop =
-    if_ (tid = 0) (gpu_pts_to_slice_sum a 0 lena s vr) **
-    mbarrier_tok lena (barrier_matrix lena a s vr) **
-    (exists* it. B.barrier_state it)
+    if_ (tid = 0) (gpu_pts_to_slice_sum a 0 lena s vr)
 
 // #push-options "--print_implicits"
 inline_for_extraction
@@ -293,7 +289,9 @@ fn kf
   requires
     gpu **
     kpre nth a s vr tid **
-    thread_id nth tid
+    thread_id nth tid **
+    mbarrier_tok nth (barrier_matrix nth a s vr) **
+    B.barrier_state 0
   ensures
     gpu **
     kpost nth a s vr tid **
@@ -319,6 +317,11 @@ fn kf
     iteration nth a s vr tid !n;
     n := !n +^ 1sz;
   };
+
+  drop_ (mbarrier_tok nth (barrier_matrix nth a s vr));
+  drop_ (B.barrier_state _);
+
+  ()
 }
 
 ghost
@@ -366,20 +369,12 @@ fn block_setup
   ()
   norewrite
   requires
-    can_create_barrier lena **
     a |-> va
   ensures
-    consumed_can_create_barrier **
     (forall+ (i : natlt lena). kpre lena a va vr i) **
     emp
 {
   gpu_array_slice_1 a;
-  mk_mbarrier lena (barrier_matrix lena a va vr);
-  forevery_zip
-      _
-      (fun i ->
-        RPM.mbarrier_tok (sizet_to_nat lena) (barrier_matrix (sizet_to_nat lena) a va vr) ** B.barrier_state 0)
-    ;
 }
 
 ghost
@@ -398,20 +393,13 @@ fn block_teardown
   ensures
     gpu_pts_to_slice_sum a 0 lena va vr
 {
+  // Adjust type of equality...
   forevery_map
     (fun (j:natlt lena) ->
-      if_ (j = 0)
-        (gpu_pts_to_slice_sum a 0 (SZ.v lena) va vr) **
-      RPM.mbarrier_tok (SZ.v lena)
-        (barrier_matrix (SZ.v lena) a va vr) **
-      (exists* (it: nat). B.barrier_state it))
+      if_ (j = 0) (gpu_pts_to_slice_sum a 0 (SZ.v lena) va vr))
     (fun (j:natlt lena) ->
-      if_ (op_Equality #(natlt lena) j 0)
-        (gpu_pts_to_slice_sum a 0 (SZ.v lena) va vr))
-    fn j {
-      drop_ (RPM.mbarrier_tok _ _);
-      drop_ (B.barrier_state _);
-    };
+      if_ (op_Equality #(natlt lena) j 0) (gpu_pts_to_slice_sum a 0 (SZ.v lena) va vr))
+    fn j {};
   forevery_if_elim #(natlt lena) 0 (fun (x: natlt lena) ->
     gpu_pts_to_slice_sum a 0 (v lena) va vr);
 }
@@ -425,11 +413,15 @@ let kernel
   (#va : erased (seq et))
   (#vr : erased (seq real) { va %~ vr })
   (#_ : squash (Seq.length va == SZ.v lena))
-: kernel_desc_1_n
+: kernel_desc_1_n_barr
     (a |-> va)
     (gpu_pts_to_slice_sum a 0 lena va vr)
 = {
   nthr = lena;
+
+  barrier_contract = mbarrier_contract (barrier_matrix lena a va vr);
+  barrier_ok       = mbarrier_transform (barrier_matrix lena a va vr);
+
   f = kf lena a #va #vr;
 
   block_setup = block_setup lena a #va;

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.BlockTiling1D.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.BlockTiling1D.fst
@@ -73,6 +73,20 @@ let barrier_q
   : B.barrier_side tile =
   fun it tid -> barrier_p m1 m2 (it+1) tid (* flip flop *)
 
+let barrier_contract
+  (#et : Type0)
+  (tile : valid_tile)
+  (* This is defined over the base shared gpu_arrays, as
+  this spec must make sense before the arrays are viewed as
+  a matrix. *)
+  (l1 l2 : full_mlayout tile tile)
+  (ar1 ar2 : gpu_array et (tile * tile))
+  : B.contract tile =
+  {
+    rin  = barrier_p (M.from_array l1 ar1) (M.from_array l2 ar2);
+    rout = barrier_q (M.from_array l1 ar1) (M.from_array l2 ar2);
+  }
+
 (* without shmem ownership *)
 unfold
 let kpre1
@@ -129,21 +143,6 @@ let kpost1
       ii tid v)
 
 unfold
-let barrier_tok
-  (#et : Type0)
-  (tile : valid_tile)
-  (* This is defined over the base shared gpu_arrays, as
-  this spec must make sense before the arrays are viewed as
-  a matrix. *)
-  (l1 l2 : full_mlayout tile tile)
-  (ar1 ar2 : gpu_array et (tile * tile))
-  : slprop
-  =
-  B.barrier_tok
-    (barrier_p (M.from_array l1 ar1) (M.from_array l2 ar2))
-    (barrier_q (M.from_array l1 ar1) (M.from_array l2 ar2))
-
-unfold
 let kpre
   (#et : Type0) {| scalar et |}
   (comb : binop et)
@@ -164,9 +163,7 @@ let kpre
   : slprop
   =
   kpre1 comb tile gA gB gC eA eB fA fB bid tid **
-  live_c_shmems sh #(1.0R /. tile) **
-  barrier_tok tile slA slB (fst sh) (fst (snd sh)) **
-  B.barrier_state 0
+  live_c_shmems sh #(1.0R /. tile)
 
 let kpre_block_sendable
   (#et : Type0) {| scalar et |}
@@ -210,9 +207,7 @@ let kpost
   : slprop
   =
   kpost1 comb tile gA gB gC eA eB fA fB bid tid **
-  live_c_shmems sh #(1.0R /. tile) **
-  barrier_tok tile slA slB (fst sh) (fst (snd sh)) **
-  B.barrier_state (2 * mshared)
+  live_c_shmems sh #(1.0R /. tile)
 
 let kpost_block_sendable
   (#et : Type0) {| scalar et |}
@@ -324,7 +319,9 @@ fn kf
     gpu **
     kpre comb tile slA slB gA gB gC eA eB fA fB sh bid tid **
     thread_id tile tid **
-    block_id (mrows * mcols) bid
+    block_id (mrows * mcols) bid **
+    B.barrier_tok (barrier_contract tile slA slB (fst sh) (fst (snd sh))) **
+    B.barrier_state 0
   ensures
     gpu **
     kpost comb tile slA slB gA gB gC eA eB fA fB sh bid tid **
@@ -359,11 +356,7 @@ fn kf
 
   while (let vbk = !bk; SZ.(vbk <^ mshared))
     invariant live sums
-    invariant
-      exists* (vbk : SZ.t).
-        bk |-> vbk **
-        B.barrier_state (2 * vbk) **
-        pure (vbk <= mshared)
+    invariant live bk ** pure (!bk <= mshared) ** B.barrier_state (2 * !bk)
     invariant
         (exists* (x : ematrix _ _ _). sa1 |-> Frac (1.0R /. tile) x) **
         (exists* (x : ematrix _ _ _). sa2 |-> Frac (1.0R /. tile) x)
@@ -371,13 +364,14 @@ fn kf
     pts_to_len sums;
     let vbk = !bk;
 
-    rewrite
-        (exists* (x : ematrix _ _ _). sa1 |-> Frac (1.0R /. tile) x) **
-        (exists* (x : ematrix _ _ _). sa2 |-> Frac (1.0R /. tile) x)
-      as barrier_p sa1 sa2 (2 * vbk) tid;
-
+    // Odd.. we have to go via this intermediate rewrite.
+    rewrite (exists* (x : ematrix _ _ _). sa1 |-> Frac (1.0R /. tile) x) **
+            (exists* (x : ematrix _ _ _). sa2 |-> Frac (1.0R /. tile) x)
+         as barrier_p sa1 sa2 (2 * vbk) tid;
+    rewrite barrier_p sa1 sa2 (2 * vbk) tid
+         as (barrier_contract tile slA slB ar1 ar2).rin (2 * vbk) tid;
     B.barrier_wait ();
-    rewrite (barrier_q sa1 sa2 (2 * vbk) tid)
+    rewrite (barrier_contract tile slA slB ar1 ar2).rout (2 * vbk) tid
          as own_1_col sa1 tid ** own_1_col sa2 tid;
 
     (* At this point we exclusively own a full column of the SHMEM
@@ -386,20 +380,19 @@ fn kf
     bring_2cols tile gA gB sa1 sa2 mrow vbk mcol tid;
 
     rewrite own_1_col sa1 tid ** own_1_col sa2 tid
-         as (barrier_p sa1 sa2 (2 * vbk + 1) tid);
+        as (barrier_contract tile slA slB ar1 ar2).rin (2 * vbk + 1) tid;
     B.barrier_wait ();
-    rewrite (barrier_q sa1 sa2 (2 * vbk + 1) tid)
-    as
-      (exists* (x : ematrix _ _ _). sa1 |-> Frac (1.0R /. tile) x) **
-      (exists* (x : ematrix _ _ _). sa2 |-> Frac (1.0R /. tile) x);
+    // Same odd thing.
+    rewrite (barrier_contract tile slA slB ar1 ar2).rout (2 * vbk + 1) tid
+         as barrier_q sa1 sa2 (2 * vbk + 1) tid;
+    rewrite barrier_q sa1 sa2 (2 * vbk + 1) tid
+        as (exists* (x : ematrix _ _ _). sa1 |-> Frac (1.0R /. tile) x) **
+           (exists* (x : ematrix _ _ _). sa2 |-> Frac (1.0R /. tile) x);
 
     (* At this point the SHMem cache is filled with the submatrices
        and we have RO permission to it. Compute product for our cell in
        the tile and add to sum. *)
     Kuiper.Poly.GEMM.Util.subproduct_cols tile sums sa1 sa2 bcol;
-
-    // What the hell.
-    assert (pure (2 * (vbk + 1) == 2 * vbk + 1 + 1));
 
     (* Move to next tile *)
     bk := !bk +^ 1sz;
@@ -440,12 +433,8 @@ fn kf
   M.gpu_matrix_concr sa1; rewrite each M.core sa1 as ar1;
   M.gpu_matrix_concr sa2; rewrite each M.core sa2 as ar2;
 
-  rewrite
-    B.barrier_tok (barrier_p sa1 sa2)
-      (barrier_q sa1 sa2)
-  as
-    B.barrier_tok (barrier_p (M.from_array slA ar1) (M.from_array slB ar2))
-      (barrier_q (M.from_array slA ar1) (M.from_array slB ar2));
+  drop_ (B.barrier_tok _);
+  drop_ (B.barrier_state _);
 
   rewrite each ar1 as fst sh;
   rewrite each ar2 as fst (snd sh);
@@ -509,12 +498,10 @@ fn block_setup
   ()
   norewrite
   requires
-    can_create_barrier tile **
     live_c_shmems sh **
     (forall+ (tid : natlt tile).
       kpre1 comb tile gA gB gC eA eB fA fB bid tid)
   ensures
-    consumed_can_create_barrier **
     (forall+ (tid : natlt tile).
       kpre comb tile slA slB gA gB gC eA eB fA fB sh bid tid) **
     emp (* frame *)
@@ -625,6 +612,9 @@ let mk_kernel
 = {
   nblk = mrows *^ mcols;
   nthr = tile;
+
+  barrier_contract = (fun bid ptrs -> barrier_contract tile slA slB (fst ptrs) (fst (snd ptrs)));
+  barrier_ok = magic();
 
   shmems_desc = shmems_desc et tile;
 

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.BlockTiling2D.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.BlockTiling2D.fst
@@ -109,25 +109,6 @@ let kpost1
   gB |-> Frac (fB /. (rows/tm * (cols/tn))) eB **
   ttile gC bm bn tm tn bid tid |-> ettile (MS.mmcomb comb eC eA eB) bm bn tm tn bid tid
 
-let barrier_tok
-  (#et : Type0) {| sized et, has_vec_cpy et |}
-  (#rows #shared #cols : pos)
-  (#bm : pos{bm /?+ rows})
-  (#bk : pos{bk /?+ shared})
-  (#bn : pos{bn /?+ cols})
-  (eA : ematrix et rows shared)
-  (eB : ematrix et shared cols)
-  (l1 : full_mlayout bm bk)
-  (l2 : full_mlayout bk bn)
-  (sar1 : gpu_array et (bm * bk))
-  (sar2 : gpu_array et (bk * bn))
-  (nthr : pos)
-  (bid : natlt (rows/bm * (cols/bn)))
-  : slprop
-  =
-  B.barrier_tok (FB.barrier_p eA eB (from_array l1 sar1) (from_array l2 sar2) nthr bid)
-                (FB.barrier_q eA eB (from_array l1 sar1) (from_array l2 sar2) nthr bid)
-
 unfold
 let kpre
   (#et : Type0) {| scalar et, v : has_vec_cpy et |}
@@ -158,9 +139,7 @@ let kpre
   : slprop
   =
   kpre1 comb gA eA gB eB gC eC bm bn bk tm tn fA fB bid tid **
-  live_c_shmems sh #(1.0R /. (bm/tm * (bn/tn))) **
-  barrier_tok #_ #_ #v eA eB slA slB (fst sh) (fst (snd sh)) nthr bid **
-  B.barrier_state 0
+  live_c_shmems sh #(1.0R /. (bm/tm * (bn/tn)))
 
 instance kpre_block_sendable
   (#et : Type0) (_:scalar et) (v : has_vec_cpy et)
@@ -224,9 +203,7 @@ let kpost
   : slprop
   =
   kpost1 comb gA eA gB eB gC eC bm bn bk tm tn fA fB bid tid **
-  live_c_shmems sh #(1.0R /. (bm/tm * (bn/tn))) **
-  barrier_tok #_ #_ #v eA eB slA slB (fst sh) (fst (snd sh)) nthr bid **
-  B.barrier_state (2 * (shared / bk))
+  live_c_shmems sh #(1.0R /. (bm/tm * (bn/tn)))
 
 instance kpost_block_sendable
   (#et : Type0) (_:scalar et) (v : has_vec_cpy et)
@@ -259,10 +236,6 @@ instance kpost_block_sendable
 : is_send_across block_of
   (kpost comb gA eA gB eB gC eC bm bn bk slA slB tm tn fA fB nthr sh i j)
 = solve
-
-let flat_matrix (#et : Type0) (#rows #cols : nat) (m : ematrix et rows cols)
-  : GTot (lseq et (rows * cols))
-  = Seq.init_ghost (rows * cols) (fun idx -> macc m (idx / cols) (idx % cols))
 
 inline_for_extraction noextract
 fn subproducts2d
@@ -489,7 +462,9 @@ fn kf
     gpu **
     kpre comb gA eA gB eB gC eC bm bn bk slA slB tm tn fA fB nthr sh bid tid **
     thread_id (bm/tm * (bn/tn)) tid **
-    block_id (rows/bm * (cols/bn)) bid
+    block_id (rows/bm * (cols/bn)) bid **
+    B.barrier_tok (FB.contract eA eB slA slB (fst sh) (fst (snd sh)) nthr bid) **
+    B.barrier_state 0
   ensures
     gpu **
     kpost comb gA eA gB eB gC eC bm bn bk slA slB tm tn fA fB nthr sh bid tid **
@@ -503,8 +478,6 @@ fn kf
   gpu_pts_to_ref sarB;
   gpu_matrix_pts_to_ref gA;
   gpu_matrix_pts_to_ref gB;
-
-  unfold barrier_tok eA eB slA slB sarA sarB nthr bid;
 
   gpu_matrix_abs' slA sarA;
   let sA = from_array slA sarA;
@@ -542,17 +515,20 @@ fn kf
   {
     even_2x !bkIdx;
     #set-options "--z3rlimit 60" {
-    rewrite
-        (exists* emA. FB.bp_sharing sA emA nthr) **
-        (exists* emB. FB.bp_sharing sB emB nthr)
-      as FB.barrier_p eA eB sA sB nthr bid (2 * !bkIdx) tid;
+      rewrite (exists* emA. FB.bp_sharing sA emA nthr) **
+              (exists* emB. FB.bp_sharing sB emB nthr)
+          as FB.barrier_p eA eB sA sB nthr bid (2 * !bkIdx) tid;
+      rewrite FB.barrier_p eA eB sA sB nthr bid (2 * !bkIdx) tid
+          as (FB.contract eA eB slA slB sarA sarB nthr bid).rin (2 * !bkIdx) tid;
     };
 
     B.barrier_wait ();
 
+    rewrite (FB.contract eA eB slA slB sarA sarB nthr bid).rout (2 * !bkIdx) tid
+         as (FB.barrier_q eA eB sA sB nthr bid (2 * !bkIdx) tid);
     rewrite (FB.barrier_q eA eB sA sB nthr bid (2 * !bkIdx) tid)
-        as live_strided_chunks sA nthr tid **
-           live_strided_chunks sB nthr tid;
+         as live_strided_chunks sA nthr tid **
+            live_strided_chunks sB nthr tid;
 
     copy_tiles_out_of_matrices_vec bm bn bk sA sB gA gB mrow !bkIdx mcol (bm/^tm*^(bn/^tn)) tid;
 
@@ -564,6 +540,8 @@ fn kf
     rewrite own_strided_chunks sA (ematrix_subtile eA bm bk mrow !bkIdx) nthr tid **
             own_strided_chunks sB (ematrix_subtile eB bk bn !bkIdx mcol) nthr tid
          as FB.barrier_p eA eB sA sB nthr bid (2 * !bkIdx + 1) tid;
+    rewrite FB.barrier_p eA eB sA sB nthr bid (2 * !bkIdx + 1) tid
+         as (FB.contract eA eB slA slB sarA sarB nthr bid).rin (2 * !bkIdx + 1) tid;
 
     B.barrier_wait ();
 
@@ -574,10 +552,11 @@ fn kf
     assert pure ((2 * !bkIdx + 1) < (2 * (shared /^ bk)));
     assert pure ((2 * !bkIdx + 1) / 2 == !bkIdx);
     #set-options "--z3rlimit 60" {
-    rewrite FB.barrier_q eA eB sA sB nthr bid (2 * !bkIdx + 1) tid
-    as
-      FB.bp_sharing sA (ematrix_subtile eA bm bk mrow !bkIdx) nthr **
-      FB.bp_sharing sB (ematrix_subtile eB bk bn !bkIdx mcol) nthr;
+      rewrite (FB.contract eA eB slA slB sarA sarB nthr bid).rout (2 * !bkIdx + 1) tid
+          as FB.barrier_q eA eB sA sB nthr bid (2 * !bkIdx + 1) tid;
+      rewrite FB.barrier_q eA eB sA sB nthr bid (2 * !bkIdx + 1) tid
+          as FB.bp_sharing sA (ematrix_subtile eA bm bk mrow !bkIdx) nthr **
+              FB.bp_sharing sB (ematrix_subtile eB bk bn !bkIdx mcol) nthr;
     };
 
     unfold FB.bp_sharing sA (ematrix_subtile eA bm bk mrow !bkIdx) nthr;
@@ -608,17 +587,8 @@ fn kf
   gpu_matrix_concr sA; rewrite each core sA as sarA;
   gpu_matrix_concr sB; rewrite each core sB as sarB;
 
-  rewrite
-    B.barrier_tok (FB.barrier_p eA eB sA sB nthr bid)
-      (FB.barrier_q eA eB sA sB nthr bid)
-  as
-    B.barrier_tok (FB.barrier_p eA eB (from_array slA sarA)
-          (from_array slB sarB)
-          nthr bid)
-      (FB.barrier_q eA eB (from_array slA sarA)
-          (from_array slB sarB)
-          nthr bid);
-  fold barrier_tok eA eB slA slB sarA sarB nthr bid;
+  drop_ (B.barrier_tok _);
+  drop_ (B.barrier_state _);
 
   rewrite each sarA as fst sh;
   rewrite each sarB as fst (snd sh);
@@ -699,12 +669,10 @@ fn block_setup
   ()
   norewrite
   requires
-    can_create_barrier nthr **
     live_c_shmems sh **
     (forall+ (tid : natlt nthr).
       kpre1 comb gA eA gB eB gC eC bm bn bk tm tn fA fB bid tid)
   ensures
-    consumed_can_create_barrier **
     (forall+ (tid : natlt nthr).
       kpre comb gA eA gB eB gC eC bm bn bk slA slB tm tn fA fB nthr sh bid tid) **
     emp (* frame *)
@@ -844,6 +812,9 @@ let mk_kernel
   nthr;// = (bm /^ tm *^ (bn /^ tn));
 
   shmems_desc = shmems_desc et bm bn bk;
+
+  barrier_contract = (fun bid ptrs -> FB.contract eA eB slA slB (fst ptrs) (fst (snd ptrs)) nthr bid);
+  barrier_ok = (fun bid ptrs -> FB.barrier_p_to_q_transform eA eB slA slB (fst ptrs) (fst (snd ptrs)) nthr bid);
 
   frame = emp;
   block_pre  = (fun bid -> forall+ (tid : natlt nthr). kpre1  comb gA eA gB eB gC eC bm bn bk tm tn fA fB bid tid);

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.FlipFlopBarrier.fsti
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.FlipFlopBarrier.fsti
@@ -41,8 +41,6 @@ let barrier_p
   (bid : natlt (rows/bm * (cols/bn)))
   : B.barrier_side nthr =
   fun it tid ->
-    let mrow = bid / (cols/bn) in
-    let mcol = bid % (cols/bn) in
     (* Barrier contract must be infinite, currently, but we will
        stop after this amount of steps. *)
     if it >= 2 * shared / bk then
@@ -57,6 +55,8 @@ let barrier_p
     else
       (* After populating a bit of this matrix, we will give back
          exclusive access to the properly filled strided chunks. *)
+      let mrow = bid / (cols/bn) in
+      let mcol = bid % (cols/bn) in
       own_strided_chunks m1 (ematrix_subtile eA bm bk mrow (it / 2)) nthr tid **
       own_strided_chunks m2 (ematrix_subtile eB bk bn (it / 2) mcol) nthr tid
 
@@ -76,8 +76,6 @@ let barrier_q
   (bid : natlt (rows/bm * (cols/bn)))
   : B.barrier_side nthr =
   fun it tid ->
-    let mrow = bid / (cols/bn) in
-    let mcol = bid % (cols/bn) in
     (* Barrier contract must be infinite, currently, but we will
        stop after this amount of steps. *)
     if it >= 2 * shared / bk then
@@ -90,8 +88,30 @@ let barrier_q
     else
       (* We get back shared, read-only access to the matrix. Over the
          *proper* contents. *)
+      let mrow = bid / (cols/bn) in
+      let mcol = bid % (cols/bn) in
       bp_sharing m1 (ematrix_subtile eA bm bk mrow (it / 2)) nthr **
       bp_sharing m2 (ematrix_subtile eB bk bn (it / 2) mcol) nthr
+
+let contract 
+  (#et : Type0) {| sized et, has_vec_cpy et |}
+  (#rows #shared #cols : pos)
+  (eA : ematrix et rows shared)
+  (eB : ematrix et shared cols)
+  (#bm : pos{bm /?+ rows})
+  (#bk : pos{bk /?+ shared})
+  (#bn : pos{bn /?+ cols})
+  (l1 : full_mlayout bm bk)
+  (l2 : full_mlayout bk bn)
+  (sar1 : gpu_array et (bm * bk))
+  (sar2 : gpu_array et (bk * bn))
+  (nthr : pos)
+  (bid : natlt (rows/bm * (cols/bn)))
+  : B.contract nthr =
+{
+  B.rin  = barrier_p eA eB (from_array l1 sar1) (from_array l2 sar2) nthr bid;
+  B.rout = barrier_q eA eB (from_array l1 sar1) (from_array l2 sar2) nthr bid;
+}
 
 let barrier_tok
   (#et : Type0) {| sized et, has_vec_cpy et |}
@@ -111,9 +131,7 @@ let barrier_tok
   (nthr : pos)
   (bid : natlt (rows/bm * (cols/bn)))
   : slprop
-  =
-  B.barrier_tok (barrier_p eA eB (from_array l1 sar1) (from_array l2 sar2) nthr bid)
-                (barrier_q eA eB (from_array l1 sar1) (from_array l2 sar2) nthr bid)
+  = B.barrier_tok (contract eA eB l1 l2 sar1 sar2 nthr bid)
 
 (* The proof of correctness. *)
 ghost

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.OrigBlockTiling1D.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.OrigBlockTiling1D.fst
@@ -5,29 +5,18 @@ module Kuiper.Poly.GEMM.OrigBlockTiling1D
 #set-options "--z3rlimit 30"
 
 open Kuiper
-open Kuiper.Matrix.Reprs.Type
-open Kuiper.Math { even, odd, even_2x, odd_2x1 }
 open Kuiper.EMatrix
-
-module M = Kuiper.Matrix
-open Kuiper.Matrix {
-  gpu_matrix,
-  gpu_matrix_pts_to,
-  gpu_matrix_pts_to_cell,
-}
+open Kuiper.Math { even, odd, even_2x, odd_2x1 }
+open Kuiper.Matrix { gpu_matrix, gpu_matrix_pts_to, gpu_matrix_pts_to_cell, }
+open Kuiper.Matrix.Reprs.Type
 open Kuiper.Matrix.Tiling
-module Trade = Pulse.Lib.Trade
-module MS = Kuiper.Spec.GEMM
-module SZ = Kuiper.SizeT
+
 module B = Kuiper.Barrier
-
+module M = Kuiper.Matrix
+module MS = Kuiper.Spec.GEMM
 module R = Kuiper.Matrix.Reprs
-
-open Kuiper.VArray {
-  varray,
-  varray_pts_to,
-  varray_pts_to_cell
-}
+module SZ = Kuiper.SizeT
+module Trade = Pulse.Lib.Trade
 
 (* Description of shared memory used in this kernel. *)
 inline_for_extraction noextract
@@ -178,23 +167,18 @@ let barrier_q
   : B.barrier_side (bm/tm * bn) =
   fun it tid -> barrier_p tm m1 m2 (it+1) tid (* flip flop *)
 
-
-let barrier_tok
+let barrier_contract
   (#et : Type0)
   (#bm #bn #bk : szp)
-  (tm : szp{tm /?+ bm})
+  (tm : szp{tm `divides` bm})
   (#_: squash ((bm/tm * bn) == bm * bk /\ (bm/tm * bn) == bn * bk))
-  (* This is defined over the base shared gpu_arrays, as
-  this spec must make sense before the arrays are viewed as
-  a matrix. *)
-  (l1 : full_mlayout bm bk)
-  (l2 : full_mlayout bk bn)
-  (sar1 : gpu_array et (bm * bk))
-  (sar2 : gpu_array et (bk * bn))
-  : slprop
-  =
-  B.barrier_tok (barrier_p tm (M.from_array l1 sar1) (M.from_array l2 sar2))
-                (barrier_q tm (M.from_array l1 sar1) (M.from_array l2 sar2))
+  (#l1 : full_mlayout bm bk)
+  (#l2 : full_mlayout bk bn)
+  (m1 : gpu_matrix et l1)
+  (m2 : gpu_matrix et l2) : B.contract (bm/tm * bn) = {
+    rin = barrier_p tm m1 m2;
+    rout = barrier_q tm m1 m2;
+  }
 
 unfold
 let kpre
@@ -225,9 +209,7 @@ let kpre
   =
   kpre1 comb tm gA gB gC eA eB eC fA fB bid tid **
   (exists* (x : seq _). fst sh |-> Frac (1.0R /. (bm/tm * bn)) x) **
-  (exists* (x : seq _). fst (snd sh) |-> Frac (1.0R /. (bm/tm * bn)) x) **
-  barrier_tok tm slA slB (fst sh) (fst (snd sh)) **
-  B.barrier_state 0
+  (exists* (x : seq _). fst (snd sh) |-> Frac (1.0R /. (bm/tm * bn)) x)
 
 unfold
 let kpost
@@ -258,9 +240,7 @@ let kpost
   =
   kpost1 comb tm gA gB gC eA eB eC fA fB bid tid **
   (exists* (x : seq _). fst sh |-> Frac (1.0R /. (bm/tm * bn)) x) **
-  (exists* (x : seq _). fst (snd sh) |-> Frac (1.0R /. (bm/tm * bn)) x) **
-  barrier_tok tm slA slB (fst sh) (fst (snd sh)) **
-  B.barrier_state (2 * mshared)
+  (exists* (x : seq _). fst (snd sh) |-> Frac (1.0R /. (bm/tm * bn)) x)
 
 inline_for_extraction noextract
 fn populate_shmem
@@ -393,7 +373,9 @@ fn kf
     gpu **
     kpre comb tm slA slB gA gB gC eA eB eC fA fB sh bid tid **
     thread_id (bm/tm * bn) tid **
-    block_id (mrows * mcols) bid
+    block_id (mrows * mcols) bid **
+    B.barrier_tok (barrier_contract tm (M.from_array slA (fst sh)) (M.from_array slB (fst (snd sh)))) **
+    B.barrier_state 0
   ensures
     gpu **
     kpost comb tm slA slB gA gB gC eA eB eC fA fB sh bid tid **
@@ -404,8 +386,6 @@ fn kf
 
   gpu_pts_to_ref sarA;
   gpu_pts_to_ref sarB;
-
-  unfold barrier_tok tm slA slB sarA sarB;
 
   M.gpu_matrix_abs' slA sarA;
   let sA = M.from_array slA sarA;
@@ -435,12 +415,16 @@ fn kf
       (exists* (x : ematrix _ _ _). sB |-> Frac (1.0R /. (bm/tm * bn)) x)
   {
     even_2x !bkIdx;
-    rewrite
-        (exists* (x : ematrix _ _ _). sA |-> Frac (1.0R /. (bm/tm * bn)) x) **
-        (exists* (x : ematrix _ _ _). sB |-> Frac (1.0R /. (bm/tm * bn)) x)
-      as barrier_p tm sA sB (2 * !bkIdx) tid;
+    rewrite (exists* (x : ematrix _ _ _). sA |-> Frac (1.0R /. (bm/tm * bn)) x) **
+            (exists* (x : ematrix _ _ _). sB |-> Frac (1.0R /. (bm/tm * bn)) x)
+         as barrier_p tm sA sB (2 * !bkIdx) tid;
+    rewrite barrier_p tm sA sB (2 * !bkIdx) tid
+         as (barrier_contract tm sA sB).rin (2 * !bkIdx) tid;
 
     B.barrier_wait ();
+
+    rewrite (barrier_contract tm sA sB).rout (2 * !bkIdx) tid
+         as barrier_q tm sA sB (2 * !bkIdx) tid;
     rewrite barrier_q tm sA sB (2 * !bkIdx) tid
          as own_1_cell sA (tid/bk) (tid%bk) ** own_1_cell sB (tid/bn) (tid%bn);
 
@@ -452,12 +436,17 @@ fn kf
     assert pure (odd (2 * !bkIdx + 1));
     rewrite own_1_cell sA (tid/bk) (tid%bk) ** own_1_cell sB (tid/bn) (tid%bn)
          as barrier_p tm sA sB (2 * !bkIdx + 1) tid;
+    rewrite barrier_p tm sA sB (2 * !bkIdx + 1) tid
+         as (barrier_contract tm sA sB).rin (2 * !bkIdx + 1) tid;
+
     B.barrier_wait ();
     even_2x (!bkIdx + 1);
     (* sigh *)
     let vbkIdx = !bkIdx;
     assert (pure (2 * (vbkIdx + 1) == 2 * vbkIdx + 1 + 1));
     assert (pure (even (2 * vbkIdx + 2)));
+    rewrite (barrier_contract tm sA sB).rout (2 * vbkIdx + 1) tid
+         as barrier_q tm sA sB (2 * vbkIdx + 1) tid;
     rewrite barrier_q tm sA sB (2 * vbkIdx + 1) tid
     as
       (exists* (x : ematrix _ _ _). sA |-> Frac (1.0R /. (bm/tm * bn)) x) **
@@ -526,10 +515,14 @@ fn kf
 
   rewrite each sA as M.from_array slA sarA;
   rewrite each sB as M.from_array slB sarB;
-  fold barrier_tok tm slA slB sarA sarB;
 
   rewrite each sarA as fst sh;
   rewrite each sarB as fst (snd sh);
+
+  drop_ (B.barrier_tok _);
+  drop_ (B.barrier_state _);
+
+  ();
 }
 #pop-options
 
@@ -598,12 +591,10 @@ fn block_setup
   ()
   norewrite
   requires
-    can_create_barrier (bm /^ tm *^ bn) **
     live_c_shmems sh **
     (forall+ (tid : natlt (bm/^tm *^ bn)).
       kpre1 comb tm gA gB gC eA eB eC fA fB bid tid)
   ensures
-    consumed_can_create_barrier **
     (forall+ (tid : natlt (bm/^tm *^ bn)).
       kpre comb tm slA slB gA gB gC eA eB eC fA fB sh bid tid) **
     emp (* frame *)
@@ -726,6 +717,9 @@ let mk_kernel
   nthr = (bm /^ tm *^ bn);
 
   shmems_desc = shmems_desc et bm bn bk;
+
+  barrier_contract = (fun bid ptrs -> barrier_contract tm (M.from_array slA (fst ptrs)) (M.from_array slB (fst (snd ptrs))));
+  barrier_ok = (fun bid ptrs -> magic());
 
   frame = emp;
   block_pre  = (fun bid -> forall+ (tid : natlt (bm/^tm *^ bn)). kpre1  comb tm gA gB gC eA eB eC fA fB bid tid);

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.SHMem.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.SHMem.fst
@@ -64,6 +64,26 @@ let barrier_q
   : B.barrier_side (tile *^ tile) =
   fun it tid -> barrier_p m1 m2 (it+1) tid (* flip flop *)
 
+let barrier_contract
+  (#et : Type0)
+  (#tile : valid_tile)
+  (#l1 : full_mlayout tile tile) (m1 : gpu_matrix et l1)
+  (#l2 : full_mlayout tile tile) (m2 : gpu_matrix et l2)
+  : B.contract (tile *^ tile) =
+{
+  rin = barrier_p m1 m2;
+  rout = barrier_q m1 m2;
+}
+
+// let barrier_tok
+//   (#et : Type0)
+//   (tile : valid_tile)
+//   (l1 l2 : full_mlayout tile tile)
+//   (ar1 ar2 : gpu_array et (tile * tile))
+//   : slprop
+//   =
+//   B.barrier_tok (barrier_contract (M.from_array l1 ar1) (M.from_array l2 ar2))
+
 (* without shmem ownership *)
 unfold
 let kpre1
@@ -118,17 +138,6 @@ let kpost1
       #1.0R
       (tid / tile) (tid % tile) v)
 
-let barrier_tok
-  (#et : Type0)
-  (tile : valid_tile)
-  (l1 l2 : full_mlayout tile tile)
-  (ar1 ar2 : gpu_array et (tile * tile))
-  : slprop
-  =
-  B.barrier_tok
-    (barrier_p (M.from_array l1 ar1) (M.from_array l2 ar2))
-    (barrier_q (M.from_array l1 ar1) (M.from_array l2 ar2))
-
 unfold
 let kpre
   (#et : Type0) {| scalar et |}
@@ -153,9 +162,7 @@ let kpre
   =
   kpre1 comb tile gA gB gC eA eB fA fB bid tid **
   (exists* x. gpu_pts_to_array (fst sh) #(1.0R /. (tile * tile)) x) **
-  (exists* x. gpu_pts_to_array (fst (snd sh)) #(1.0R /. (tile * tile)) x) **
-  barrier_tok tile slA slB (fst sh) (fst (snd sh)) **
-  B.barrier_state 0
+  (exists* x. gpu_pts_to_array (fst (snd sh)) #(1.0R /. (tile * tile)) x)
 
 unfold
 let kpost
@@ -180,9 +187,7 @@ let kpost
   =
   kpost1 comb tile gA gB gC eA eB fA fB bid tid **
   (exists* x. gpu_pts_to_array (fst sh) #(1.0R /. (tile * tile)) x) **
-  (exists* x. gpu_pts_to_array (fst (snd sh)) #(1.0R /. (tile * tile)) x) **
-  barrier_tok tile slA slB (fst sh) (fst (snd sh)) **
-  B.barrier_state (2 * mshared)
+  (exists* x. gpu_pts_to_array (fst (snd sh)) #(1.0R /. (tile * tile)) x)
 
 (* TODO: Find out where the time is going when checking this function,
 it feels a lot slower than the others. *)
@@ -213,7 +218,9 @@ fn kf
     gpu **
     kpre comb tile slA slB gA gB gC eA eB fA fB sh bid tid **
     thread_id (tile * tile) tid **
-    block_id (mrows * mcols) bid
+    block_id (mrows * mcols) bid **
+    B.barrier_tok (barrier_contract (M.from_array slA (fst sh)) (M.from_array slB (fst (snd sh)))) **
+    B.barrier_state 0
   ensures
     gpu **
     kpost comb tile slA slB gA gB gC eA eB fA fB sh bid tid **
@@ -224,8 +231,6 @@ fn kf
 
   gpu_pts_to_ref ar1;
   gpu_pts_to_ref ar2;
-
-  unfold barrier_tok tile slA slB ar1 ar2;
 
   M.gpu_matrix_abs' slA ar1;
   let sa1 = M.from_array slA ar1;
@@ -279,10 +284,10 @@ fn kf
     rewrite
         (exists* (x : ematrix _ _ _). sa1 |-> Frac (1.0R /. (tile * tile)) x) **
         (exists* (x : ematrix _ _ _). sa2 |-> Frac (1.0R /. (tile * tile)) x)
-      as barrier_p sa1 sa2 (2 * vbk) tid;
+      as (barrier_contract sa1 sa2).rin (2 * vbk) tid; 
 
     B.barrier_wait ();
-    rewrite (barrier_q sa1 sa2 (2 * vbk) tid)
+    rewrite (barrier_contract sa1 sa2).rout (2 * vbk) tid
          as (exists* x. gpu_matrix_pts_to_cell sa1 (tid / tile) (tid % tile) x) **
             (exists* x. gpu_matrix_pts_to_cell sa2 (tid / tile) (tid % tile) x);
 
@@ -307,9 +312,9 @@ fn kf
 
     rewrite (exists* x. gpu_matrix_pts_to_cell sa1 (tid / tile) (tid % tile) x) **
             (exists* x. gpu_matrix_pts_to_cell sa2 (tid / tile) (tid % tile) x)
-         as (barrier_p sa1 sa2 (2 * vbk + 1) tid);
+         as (barrier_contract sa1 sa2).rin (2 * vbk + 1) tid;
     B.barrier_wait ();
-    rewrite (barrier_q sa1 sa2 (2 * vbk + 1) tid)
+    rewrite (barrier_contract sa1 sa2).rout (2 * vbk + 1) tid
     as
       (exists* (x : ematrix _ _ _). sa1 |-> Frac (1.0R /. (tile * tile)) x) **
       (exists* (x : ematrix _ _ _). sa2 |-> Frac (1.0R /. (tile * tile)) x);
@@ -366,7 +371,9 @@ fn kf
   M.gpu_matrix_concr sa1; rewrite each M.core sa1 as ar1;
   M.gpu_matrix_concr sa2; rewrite each M.core sa2 as ar2;
 
-  fold barrier_tok tile slA slB ar1 ar2;
+  // fold barrier_tok tile slA slB ar1 ar2;
+  drop_ (B.barrier_tok _);
+  drop_ (B.barrier_state _);
 
   rewrite each ar1 as fst sh;
   rewrite each ar2 as fst (snd sh);
@@ -428,12 +435,10 @@ fn block_setup
   ()
   norewrite
   requires
-    can_create_barrier (tile *^ tile) **
     live_c_shmems sh **
     (forall+ (tid : natlt2 tile  tile).
       kpre1 comb tile gA gB gC eA eB fA fB bid tid)
   ensures
-    consumed_can_create_barrier **
     (forall+ (tid : natlt2 tile  tile).
       kpre comb tile slA slB gA gB gC eA eB fA fB sh bid tid) **
     emp (* frame *)
@@ -536,6 +541,11 @@ let mk_kernel
 = {
   nblk = mrows *^ mcols;
   nthr = tile *^ tile;
+
+  barrier_contract = (fun bid ptrs -> barrier_contract
+                        (M.from_array slA (fst ptrs))
+                        (M.from_array slB (fst (snd ptrs))));
+  barrier_ok = magic();
 
   shmems_desc = shmems_desc et tile;
 

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.TensorCore.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.TensorCore.fst
@@ -4,31 +4,23 @@ module Kuiper.Poly.GEMM.TensorCore
 
 open Kuiper
 
-#set-options "--z3rlimit 20"
+#set-options "--z3rlimit 40"
 
-open Kuiper.Matrix.Reprs.Type
-open Kuiper.Math { even, odd, even_2x, odd_2x1 }
-
-open Kuiper.Matrix
-
-module MS = Kuiper.Spec.GEMM
-module SZ = Kuiper.SizeT
-module B = Kuiper.Barrier
-
-module R = Kuiper.Matrix.Reprs
-
-open Kuiper.EMatrix { ematrix }
-open Kuiper.VArray {
-  varray,
-  varray_pts_to,
-  varray_pts_to_cell
-}
-open Kuiper.TensorCore
+open Kuiper.Array.Vectorized { has_vec_cpy, chunk }
 open Kuiper.Float16
+open Kuiper.Math { even, odd, even_2x, odd_2x1 }
+open Kuiper.Matrix
+open Kuiper.Matrix.Reprs.Type
 open Kuiper.Matrix.Tiling
+open Kuiper.Poly.GEMM.Copy.Vec
+open Kuiper.Poly.GEMM.Tiled.Common.Vec
+open Kuiper.TensorCore
 
-open Kuiper.Poly.GEMM.Copy
-open Kuiper.Poly.GEMM.Tiled.Common
+module B = Kuiper.Barrier
+module MS = Kuiper.Spec.GEMM
+module R = Kuiper.Matrix.Reprs
+module SZ = Kuiper.SizeT
+module FB = Kuiper.Poly.GEMM.FlipFlopBarrier
 
 let live_warp_tile
   (#et : Type0) {| scalar et |}
@@ -109,50 +101,6 @@ let kpost1
   gB |-> Frac (fB /. (rows/tm * (cols/tn) * warp_size)) eB **
   live_warp_tile gC bm bn tm tn bid (tid/warp_size)
 
-let barrier_p
-  (#et : Type0)
-  (#bm #bn #bk : szp)
-  (#l1 : mlayout bm bk)
-  (#l2 : mlayout bk bn)
-  (m1 : gpu_matrix et l1)
-  (m2 : gpu_matrix et l2)
-  (nthr : pos)
-  : B.barrier_side nthr =
-  fun it tid ->
-    if even it then
-      (exists* (x : ematrix _ _ _). m1 |-> Frac (1.0R /. nthr) x) **
-      (exists* (x : ematrix _ _ _). m2 |-> Frac (1.0R /. nthr) x)
-    else
-      live_strided_chunks m1 nthr tid **
-      live_strided_chunks m2 nthr tid
-
-let barrier_q
-  (#et : Type0)
-  (#bm #bn #bk : szp)
-  (#l1 : mlayout bm bk)
-  (#l2 : mlayout bk bn)
-  (m1 : gpu_matrix et l1)
-  (m2 : gpu_matrix et l2)
-  (nthr : pos)
-  : B.barrier_side nthr =
-  fun it tid -> barrier_p m1 m2 nthr (it+1) tid (* flip flop *)
-
-let barrier_tok
-  (#et : Type0)
-  (#bm #bn #bk : szp)
-  (* This is defined over the base shared gpu_arrays, as
-  this spec must make sense before the arrays are viewed as
-  a matrix. *)
-  (l1 : full_mlayout bm bk)
-  (l2 : full_mlayout bk bn)
-  (sar1 : gpu_array et (bm * bk))
-  (sar2 : gpu_array et (bk * bn))
-  (nthr : pos)
-  : slprop
-  =
-  B.barrier_tok (barrier_p (from_array l1 sar1) (from_array l2 sar2) nthr)
-                (barrier_q (from_array l1 sar1) (from_array l2 sar2) nthr)
-
 unfold
 let kpre
   (#et_ab #et_c : Type0) {| scalar et_ab, scalar et_c |}
@@ -180,9 +128,7 @@ let kpre
   =
   kpre1 gA eA gB eB gC bm bn bk tm tn tk fA fB bid tid **
   (exists* (x : seq _). gpu_pts_to_array (fst sh)       #(1.0R /. (bm/tm*(bn/tn)*warp_size)) x) **
-  (exists* (x : seq _). gpu_pts_to_array (fst (snd sh)) #(1.0R /. (bm/tm*(bn/tn)*warp_size)) x) **
-  barrier_tok (R.row_major bm bk) (R.row_major bk bn) (fst sh) (fst (snd sh)) (bm/tm * (bn/tn) * warp_size) **
-  B.barrier_state 0
+  (exists* (x : seq _). gpu_pts_to_array (fst (snd sh)) #(1.0R /. (bm/tm*(bn/tn)*warp_size)) x)
 
 unfold
 let kpost
@@ -210,9 +156,7 @@ let kpost
   =
   kpost1 gA eA gB eB gC bm bn tm tn fA fB bid tid **
   exists* (x : seq _). fst sh |-> Frac (1.0R /. (bm/tm*(bn/tn)*warp_size)) x **
-  exists* (x : seq _). fst (snd sh) |-> Frac (1.0R /. (bm/tm*(bn/tn)*warp_size)) x **
-  barrier_tok (R.row_major bm bk) (R.row_major bk bn) (fst sh) (fst (snd sh)) (bm/tm * (bn/tn) * warp_size) **
-  B.barrier_state (2 * (shared/bk))
+  exists* (x : seq _). fst (snd sh) |-> Frac (1.0R /. (bm/tm*(bn/tn)*warp_size)) x
 
 inline_for_extraction noextract
 fn subproducts_tc
@@ -281,7 +225,6 @@ fn subproducts_tc
   ()
 }
 
-#set-options "--print_implicits"
 inline_for_extraction noextract
 fn epilogue
   (#et : Type0) {| scalar et |}
@@ -333,18 +276,22 @@ fn epilogue
 inline_for_extraction noextract
 fn kf
   (#et_ab #et_c : Type0)
-  {| scalar et_ab, scalar et_c |}
+  {| scalar et_ab, has_vec_cpy et_ab, scalar et_c |}
   (#rows #shared #cols : szp)
-  (#lA : mlayout rows shared) {| clayout lA |}
+  (#lA : mlayout rows shared) {| clayout lA, str_A : strided_row_major lA |}
   (gA : gpu_matrix et_ab lA)
   (#eA : ematrix et_ab rows shared)
-  (#lB : mlayout shared cols) {| clayout lB |}
+  (#lB : mlayout shared cols) {| clayout lB, str_B : strided_row_major lB |}
+  (#_ : squash (aligned_strided_row_major (chunk et_ab) str_A))
+  (#_ : squash (aligned_strided_row_major (chunk et_ab) str_B))
   (gB : gpu_matrix et_ab lB)
   (#eB : ematrix et_ab shared cols)
   (gC : gpu_matrix et_c (R.row_major rows cols))
   (bm : szp{bm /?+ rows})
   (bn : szp{bn /?+ cols})
   (bk : szp{bk /?+ shared})
+  (#_ : squash (chunk et_ab /?+ bn))
+  (#_ : squash (chunk et_ab /?+ bk))
   (#_: squash (SZ.fits (bm * bk) /\ SZ.fits (bk * bn)))
   (tm : szp{tm /?+ bm})
   (tn : szp{tn /?+ bn})
@@ -352,16 +299,23 @@ fn kf
   (#_ : squash (SZ.fits (bm*bk + bm/tm*(bn/tn)*warp_size -1)))
   (#_ : squash (SZ.fits (bk*bn + bm/tm*(bn/tn)*warp_size -1)))
   (#_ : squash (SZ.fits (rows * cols)))
+  (nthr : szp{SZ.v nthr == bm/tm * (bn/tn) * warp_size})
+  (#_ : squash (chunk et_ab * nthr /?+ (bm * bk)))
+  (#_ : squash (chunk et_ab * nthr /?+ (bk * bn)))
+  (#_ : squash (aligned 16 (core gA)))
+  (#_ : squash (aligned 16 (core gB)))
   (#fA #fB : perm)
   (sh : c_shmems (shmems_desc et_ab bm bn bk))
   (bid : szlt (rows/bm * (cols/bn)))
-  (tid : szlt (bm/tm * (bn/tn) * warp_size))
+  (tid : szlt nthr)
   ()
   requires
     gpu **
     kpre gA eA gB eB gC bm bn bk tm tn tk fA fB sh bid tid **
     thread_id (bm/tm * (bn/tn) * warp_size) tid **
-    block_id (rows/bm * (cols/bn)) bid
+    block_id (rows/bm * (cols/bn)) bid **
+    B.barrier_tok (FB.contract eA eB (R.row_major bm bk) (R.row_major bk bn) (fst sh) (fst (snd sh)) nthr bid) **
+    B.barrier_state 0
   ensures
     gpu **
     kpost gA eA gB eB gC bm bn bk tm tn fA fB sh bid tid **
@@ -379,7 +333,6 @@ fn kf
   // assert (rewrites_to slA (R.row_major bm bk));
   // let slB = R.row_major bk bn;
   // assert (rewrites_to slB (R.row_major bk bn));
-  unfold barrier_tok (R.row_major bm bk) (R.row_major bk bn) sarA sarB (bm/tm * (bn/tn) * warp_size);
 
   gpu_matrix_abs' (R.row_major bm bk) sarA;
   let sA = from_array (R.row_major bm bk) sarA;
@@ -410,55 +363,85 @@ fn kf
   mma_loadAccum accumFrag t_tile;
   fold live_warp_tile #et_c;
 
+  with em1. fold FB.bp_sharing sA em1 nthr;
+  with em2. fold FB.bp_sharing sB em2 nthr;
+
   let mut bkIdx  : sz = 0sz;
-  while (SZ.(!bkIdx <^ num_k_tiles))
+  while (!bkIdx <^ num_k_tiles)
     invariant
-      // Why can I not use `live` here?
-      exists* (vbkIdx : SZ.t{vbkIdx <= num_k_tiles})
-        (vaFrag : ematrix et_ab tm tk) (vbFrag : ematrix et_ab tk tn) (vaccumFrag : ematrix et_c tm tn).
-        bkIdx |-> vbkIdx **
-        aFrag |-> vaFrag **
-        bFrag |-> vbFrag **
-        accumFrag |-> vaccumFrag **
-        (exists* (x : ematrix _ _ _). sA |-> Frac (1.0R /. ((bm/tm*(bn/tn) * warp_size))) x) **
-        (exists* (x : ematrix _ _ _). sB |-> Frac (1.0R /. ((bm/tm*(bn/tn) * warp_size))) x) **
-        B.barrier_state (2 * !bkIdx)
+      live bkIdx ** pure (!bkIdx <= num_k_tiles)
+    invariant
+      live aFrag ** live bFrag ** live accumFrag 
+    invariant
+      (exists* em1. FB.bp_sharing sA em1 nthr) **
+      (exists* em2. FB.bp_sharing sB em2 nthr)
+    invariant
+      B.barrier_state (2 * !bkIdx)
   {
     even_2x !bkIdx;
-    assert pure((2 * !bkIdx % 2 = 0) == true);
-    rewrite
-        (exists* (x : ematrix _ _ _). sA |-> Frac (1.0R /. (bm/tm * (bn/tn) * warp_size)) x) **
-        (exists* (x : ematrix _ _ _). sB |-> Frac (1.0R /. (bm/tm * (bn/tn) * warp_size)) x)
-      as barrier_p sA sB (bm/tm * (bn/tn) * warp_size) (2 * !bkIdx) tid;
+    assert pure ((2 * !bkIdx % 2 = 0) == true);
+    assert pure (even (2 * !bkIdx));
+    rewrite (exists* em1. FB.bp_sharing sA em1 nthr) **
+            (exists* em2. FB.bp_sharing sB em2 nthr)
+         as (FB.barrier_p eA eB sA sB nthr bid) (2 * !bkIdx) tid;
+    rewrite (FB.barrier_p eA eB sA sB nthr bid) (2 * !bkIdx) tid
+         as (FB.contract eA eB (R.row_major bm bk) (R.row_major bk bn) sarA sarB nthr bid).rin (2 * !bkIdx) tid;
 
     B.barrier_wait ();
-    rewrite (barrier_q sA sB (bm/tm * (bn/tn) * warp_size) (2 * !bkIdx) tid)
-        as live_strided_chunks sA (bm/tm * (bn/tn) * warp_size) tid **
-           live_strided_chunks sB (bm/tm * (bn/tn) * warp_size) tid;
 
-    copy_tiles_out_of_matrices bm bn bk sA sB gA gB mrow !bkIdx mcol (bm/^tm*^(bn/^tn)*^warp_sz) tid;
+    rewrite (FB.contract eA eB (R.row_major bm bk) (R.row_major bk bn) sarA sarB nthr bid).rout (2 * !bkIdx) tid
+         as (FB.barrier_q eA eB sA sB nthr bid) (2 * !bkIdx) tid;
+    assert pure (even (2 * !bkIdx));
+    assert pure (2 * !bkIdx >= 2 * shared / bk == false);
 
-    assert (B.barrier_tok (barrier_p sA sB (bm/tm * (bn/tn) * warp_size)) (barrier_q sA sB (bm/tm * (bn/tn) * warp_size)));
+    // WHY isn't this obvious?
+    assume (pure (
+               (FB.barrier_q eA eB sA sB nthr bid) (2 * !bkIdx) tid
+            ==
+              live_strided_chunks sA nthr tid **
+              live_strided_chunks sB nthr tid));
+    rewrite (FB.barrier_q eA eB sA sB nthr bid) (2 * !bkIdx) tid
+         as live_strided_chunks sA nthr tid **
+            live_strided_chunks sB nthr tid;
+
+    copy_tiles_out_of_matrices_vec bm bn bk sA sB gA gB mrow !bkIdx mcol nthr tid;
+
     odd_2x1 !bkIdx;
     assert (pure (odd (2 * !bkIdx + 1)));
-    rewrite live_strided_chunks sA (bm/tm * (bn/tn) * warp_size) tid **
-            live_strided_chunks sB (bm/tm * (bn/tn) * warp_size) tid
-         as (barrier_p sA sB (bm/tm * (bn/tn) * warp_size) (2 * !bkIdx + 1) tid);
+    #set-options "--z3rlimit 40 --retry 3" {
+      rewrite own_strided_chunks sA (ematrix_subtile eA bm bk mrow !bkIdx) nthr tid **
+              own_strided_chunks sB (ematrix_subtile eB bk bn !bkIdx mcol) nthr tid
+          as FB.barrier_p eA eB sA sB nthr bid (2 * !bkIdx + 1) tid;
+      rewrite FB.barrier_p eA eB sA sB nthr bid (2 * !bkIdx + 1) tid
+          as (FB.contract eA eB (R.row_major bm bk) (R.row_major bk bn) sarA sarB nthr bid).rin (2 * !bkIdx + 1) tid;
+    };
 
     B.barrier_wait ();
 
     even_2x (!bkIdx + 1);
     assert (pure (2 * (!bkIdx + 1) == 2 * !bkIdx + 2));
     assert (pure (even (2 * !bkIdx + 2)));
-    rewrite (barrier_q sA sB (bm/tm * (bn/tn) * warp_size) (2 * !bkIdx + 1) tid)
-    as
-      (exists* (x : ematrix _ _ _). sA |-> Frac (1.0R /. (bm/tm * (bn/tn) * warp_size)) x) **
-      (exists* (x : ematrix _ _ _). sB |-> Frac (1.0R /. (bm/tm * (bn/tn) * warp_size)) x);
+    assert (pure ((2 * !bkIdx + 1) / 2 == !bkIdx));
+    #set-options "--z3rlimit 40 --retry 3" {
+      rewrite (FB.contract eA eB (R.row_major bm bk) (R.row_major bk bn) sarA sarB nthr bid).rout (2 * !bkIdx + 1) tid
+           as FB.barrier_q eA eB sA sB nthr bid (2 * !bkIdx + 1) tid;
+      rewrite FB.barrier_q eA eB sA sB nthr bid (2 * !bkIdx + 1) tid
+           as FB.bp_sharing sA (ematrix_subtile eA bm bk mrow !bkIdx) nthr **
+              FB.bp_sharing sB (ematrix_subtile eB bk bn !bkIdx mcol) nthr;
+    };
+
+    unfold FB.bp_sharing sA (ematrix_subtile eA bm bk mrow !bkIdx) nthr;
+    unfold FB.bp_sharing sB (ematrix_subtile eB bk bn !bkIdx mcol) nthr;
 
     subproducts_tc bm bn bk tm tn tk aFrag bFrag accumFrag sA sB warpRow warpCol;
 
+    fold FB.bp_sharing sA (ematrix_subtile eA bm bk mrow !bkIdx) nthr;
+    fold FB.bp_sharing sB (ematrix_subtile eB bk bn !bkIdx mcol) nthr;
+
     bkIdx := !bkIdx +^ 1sz;
   };
+  with em1. unfold FB.bp_sharing sA em1 nthr;
+  with em2. unfold FB.bp_sharing sB em2 nthr;
 
   rewrite each (tid / 32) as wid;
   epilogue bm bn tm tn accumFrag gC bid wid;
@@ -471,17 +454,8 @@ fn kf
   gpu_matrix_concr sA; rewrite each core sA as sarA;
   gpu_matrix_concr sB; rewrite each core sB as sarB;
 
-  rewrite
-    B.barrier_tok (barrier_p sA sB (v bm / v tm * (v bn / v tn) * 32))
-      (barrier_q sA sB (v bm / v tm * (v bn / v tn) * 32))
-  as
-    B.barrier_tok (barrier_p (from_array (R.row_major (v bm) (v bk)) sarA)
-          (from_array (R.row_major (v bk) (v bn)) sarB)
-          (v bm / v tm * (v bn / v tn) * 32))
-      (barrier_q (from_array (R.row_major (v bm) (v bk)) sarA)
-          (from_array (R.row_major (v bk) (v bn)) sarB)
-          (v bm / v tm * (v bn / v tn) * 32));
-  fold barrier_tok (R.row_major bm bk) (R.row_major bk bn) sarA sarB (bm/tm * (bn/tn) * warp_size);
+  drop_ (B.barrier_tok _);
+  drop_ (B.barrier_state _);
 
   rewrite each sarA as fst sh;
   rewrite each sarB as fst (snd sh);
@@ -562,12 +536,10 @@ fn block_setup
   ()
   norewrite
   requires
-    can_create_barrier nthr **
     live_c_shmems sh **
     (forall+ (tid : natlt nthr).
       kpre1 (* comb *) gA eA gB eB gC bm bn bk tm tn tk fA fB bid tid)
   ensures
-    consumed_can_create_barrier **
     (forall+ (tid : natlt nthr).
       kpre (* comb *) gA eA gB eB gC bm bn bk tm tn tk fA fB sh bid tid) **
     emp (* frame *)
@@ -667,12 +639,14 @@ fn teardown
 inline_for_extraction noextract
 let mk_kernel
   (#et_ab #et_c : Type0)
-  {| scalar et_ab, scalar et_c |}
+  {| scalar et_ab, has_vec_cpy et_ab, scalar et_c |}
   (#rows #shared #cols : szp)
-  (#lA : mlayout rows shared) {| clayout lA |}
+  (#lA : mlayout rows shared) {| clayout lA, str_A : strided_row_major lA |}
   (gA : gpu_matrix et_ab lA { is_global_matrix gA })
   (#eA : ematrix et_ab rows shared)
-  (#lB : mlayout shared cols) {| clayout lB |}
+  (#lB : mlayout shared cols) {| clayout lB, str_B : strided_row_major lB |}
+  (#_ : squash (aligned_strided_row_major (chunk et_ab) str_A))
+  (#_ : squash (aligned_strided_row_major (chunk et_ab) str_B))
   (gB : gpu_matrix et_ab lB { is_global_matrix gB })
   (#eB : ematrix et_ab shared cols)
   (gC : gpu_matrix et_c (R.row_major rows cols) { is_global_matrix gC })
@@ -681,6 +655,8 @@ let mk_kernel
   (bm : szp{bm /?+ rows})
   (bn : szp{bn /?+ cols})
   (bk : szp{bk /?+ shared})
+  (#_ : squash (chunk et_ab /?+ bn))
+  (#_ : squash (chunk et_ab /?+ bk))
   (#_: squash (SZ.fits (bm * bk) /\ SZ.fits (bk * bn)))
   (tm : szp{tm /?+ bm})
   (tn : szp{tn /?+ bn})
@@ -694,6 +670,10 @@ let mk_kernel
   // correct: the amount of tensor core tiles in gC multiplied
   //  by the warp size (each warp computes one tile)
   (nthr : szp{SZ.v nthr == bm/tm*(bn/tn)*warp_size})
+  (#_ : squash (chunk et_ab * nthr /?+ (bm * bk)))
+  (#_ : squash (chunk et_ab * nthr /?+ (bk * bn)))
+  (#_ : squash (aligned 16 (core gA)))
+  (#_ : squash (aligned 16 (core gB)))
   (#_ : squash (valid_frag_et_dims et_ab FragA tm tn tk))
   (#_ : squash (valid_frag_et_dims et_ab FragB tm tn tk))
   (#_ : squash (valid_frag_et_dims et_c FragAcc tm tn tk))
@@ -709,6 +689,11 @@ let mk_kernel
 = {
   nblk;
   nthr;
+
+  barrier_contract = (fun bid ptrs -> FB.contract eA eB (R.row_major bm bk) (R.row_major bk bn)
+                                        (fst ptrs) (fst (snd ptrs)) nthr bid);
+  barrier_ok = (fun bid ptrs -> FB.barrier_p_to_q_transform eA eB (R.row_major bm bk) (R.row_major bk bn)
+                                        (fst ptrs) (fst (snd ptrs)) nthr bid);
 
   shmems_desc = shmems_desc et_ab bm bn bk;
 
@@ -726,7 +711,7 @@ let mk_kernel
   kpre      = kpre  gA eA gB eB gC bm bn bk tm tn tk fA fB;
   kpost     = kpost gA eA gB eB gC bm bn bk tm tn fA fB;
 
-  f = kf gA #eA gB #eB gC bm bn bk tm tn tk #() #() #() #fA #fB;
+  f = kf gA #eA gB #eB gC bm bn bk tm tn tk nthr #() #() #() #() #fA #fB;
 
   block_pre_sendable=solve;
   block_post_sendable=solve;

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.TensorCore.fsti
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.TensorCore.fsti
@@ -5,6 +5,7 @@ module Kuiper.Poly.GEMM.TensorCore
 open Kuiper
 open Kuiper.Matrix
 open Kuiper.EMatrix
+open Kuiper.Array.Vectorized { has_vec_cpy, chunk }
 
 open Kuiper.Matrix.Reprs
 open Kuiper.TensorCore
@@ -14,27 +15,41 @@ module SZ = Kuiper.SizeT
 inline_for_extraction noextract
 val mk_kernel
   (#et_ab #et_c : Type0)
-  {| scalar et_ab, scalar et_c |}
+  {| scalar et_ab, has_vec_cpy et_ab, scalar et_c |}
   (#rows #shared #cols : szp)
-  (#lA : mlayout rows shared) {| clayout lA |}
+  (#lA : mlayout rows shared) {| clayout lA, str_A : strided_row_major lA |}
   (gA : gpu_matrix et_ab lA { is_global_matrix gA })
   (#eA : ematrix et_ab rows shared)
-  (#lB : mlayout shared cols) {| clayout lB |}
+  (#lB : mlayout shared cols) {| clayout lB, str_B : strided_row_major lB |}
+  (#_ : squash (aligned_strided_row_major (chunk et_ab) str_A))
+  (#_ : squash (aligned_strided_row_major (chunk et_ab) str_B))
   (gB : gpu_matrix et_ab lB { is_global_matrix gB })
   (#eB : ematrix et_ab shared cols)
   (gC : gpu_matrix et_c (row_major rows cols) { is_global_matrix gC })
   (#_ : squash (SZ.fits (rows * cols)))
   (#eC : ematrix et_c rows cols)
-  (bm : szp{bm /? rows})
-  (bn : szp{bn /? cols})
-  (bk : szp{bk /? shared})
+  (bm : szp{bm /?+ rows})
+  (bn : szp{bn /?+ cols})
+  (bk : szp{bk /?+ shared})
+  (#_ : squash (chunk et_ab /?+ bn))
+  (#_ : squash (chunk et_ab /?+ bk))
   (#_: squash (SZ.fits (bm * bk) /\ SZ.fits (bk * bn)))
-  (tm : szp{tm /? bm})
-  (tn : szp{tn /? bn})
-  (tk : szp{tk /? bk})
+  (tm : szp{tm /?+ bm})
+  (tn : szp{tn /?+ bn})
+  (tk : szp{tk /?+ bk})
   (#fA #fB : perm)
   (nblk : szp{SZ.v nblk == rows/bm * (cols/bn)})
-  (nthr : szp{SZ.v nthr == bm/tm * (bn/tn) * warp_size})
+  // WARNING the previous version was wrong, it was assuming that each
+  //  thread computes tm*tk results similar to 2D-Blocktiling.
+  // There is nothing that catches this.
+  // (nthr : szp{SZ.v nthr == bm/tm * (bn/tn)})
+  // correct: the amount of tensor core tiles in gC multiplied
+  //  by the warp size (each warp computes one tile)
+  (nthr : szp{SZ.v nthr == bm/tm*(bn/tn)*warp_size})
+  (#_ : squash (chunk et_ab * nthr /?+ (bm * bk)))
+  (#_ : squash (chunk et_ab * nthr /?+ (bk * bn)))
+  (#_ : squash (aligned 16 (core gA)))
+  (#_ : squash (aligned 16 (core gB)))
   (#_ : squash (valid_frag_et_dims et_ab FragA tm tn tk))
   (#_ : squash (valid_frag_et_dims et_ab FragB tm tn tk))
   (#_ : squash (valid_frag_et_dims et_c FragAcc tm tn tk))

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.TensorCore2D.KernelDesc.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.TensorCore2D.KernelDesc.fst
@@ -384,12 +384,10 @@ fn block_setup
   ()
   norewrite
   requires
-    can_create_barrier nthr **
     live_c_shmems sh **
     (forall+ (tid : natlt nthr).
       kpre1 gA eA gB eB gC eC bm bn bk tm tn tk wm wn fA fB rA rB rC nthr bid tid)
   ensures
-    consumed_can_create_barrier **
     (forall+ (tid : natlt nthr).
       kpre gA eA gB eB gC eC bm bn bk tm tn tk wm wn fA fB rA rB rC nthr sh bid tid) **
     emp (* frame *)
@@ -398,17 +396,7 @@ fn block_setup
   // shmem for A tile
   gpu_live_c_shmems_share_underspec sh #(1.0R) #nthr;
 
-  (* create barrier token *)
-  B.mk_barrier nthr _ _
-    (FB.barrier_p_to_q_transform eA eB (R.row_major bm bk) (R.row_major bk bn) (fst sh) (fst (snd sh)) nthr bid);
-  let sar1 = fst sh;
-  let sar2 = fst (snd sh);
-
   (* consolidate permissions under a single forall+ *)
-  forevery_zip
-    (fun tid -> live_c_shmems sh #(recip nthr))
-    (fun tid ->
-      FB.barrier_tok #_ #_ #v eA eB (R.row_major bm bk) (R.row_major bk bn) (fst sh) (fst (snd sh)) nthr bid ** B.barrier_state 0);
   forevery_zip #(natlt nthr)
     (fun tid -> kpre1 gA eA gB eB gC eC bm bn bk tm tn tk wm wn fA fB rA rB rC nthr bid tid) _;
   ()
@@ -460,18 +448,9 @@ fn block_teardown
   forevery_unzip #(natlt nthr)
     (fun tid -> kpost1 gA eA gB eB gC eC bm bn bk tm tn tk wm wn fA fB rA rB rC nthr bid tid)
     _;
-  forevery_unzip #(natlt nthr)
-    (fun _tid -> live_c_shmems sh #(recip nthr))
-    _;
 
   (* Restore and give back ownership of shared memory arrays. *)
   gpu_live_c_shmems_gather_underspec sh #(1.0R) #nthr;
-
-  (* Drop barrier tokens. *)
-  drop_
-    (forall+ (x: natlt nthr).
-      FB.barrier_tok eA eB (R.row_major bm bk) (R.row_major bk bn) (fst sh) (fst (snd sh)) nthr bid ** B.barrier_state (2 * (shared/bk)));
-  ()
 }
 
 

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.TensorCore2D.KernelDesc.fsti
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.TensorCore2D.KernelDesc.fsti
@@ -173,10 +173,7 @@ let kpre
   : slprop
   =
   kpre1 gA eA gB eB gC eC bm bn bk tm tn tk wm wn fA fB rA rB rC nthr bid tid **
-  live_c_shmems sh #(recip nthr) **
-  FlipFlopBarrier.barrier_tok #_ #_ #v #rows #shared #cols eA eB #bm #bk #bn
-    (R.row_major bm bk) (R.row_major bk bn) (fst sh) (fst (snd sh)) nthr bid **
-  B.barrier_state 0
+  live_c_shmems sh #(recip nthr)
 
 // #push-options "--z3rlimit_factor 4 --split_queries no --fuel 0 --ifuel 0 --query_stats"
 // instance kpre_block_sendable
@@ -299,12 +296,10 @@ fn block_setup
   ()
   norewrite
   requires
-    can_create_barrier nthr **
     live_c_shmems sh **
     (forall+ (tid : natlt nthr).
       kpre1 gA eA gB eB gC eC bm bn bk tm tn tk wm wn fA fB rA rB rC nthr bid tid)
   ensures
-    consumed_can_create_barrier **
     (forall+ (tid : natlt nthr).
       kpre gA eA gB eB gC eC bm bn bk tm tn tk wm wn fA fB rA rB rC nthr sh bid tid) **
     emp (* frame *)
@@ -452,9 +447,7 @@ let kpost
   : slprop
   =
   kpost1 gA eA gB eB gC eC bm bn bk tm tn tk wm wn fA fB rA rB rC nthr bid tid **
-  live_c_shmems sh #(recip nthr) **
-  FlipFlopBarrier.barrier_tok #_ #_ #v eA eB (R.row_major bm bk) (R.row_major bk bn) (fst sh) (fst (snd sh)) nthr bid **
-  B.barrier_state (2 * (shared/bk))
+  live_c_shmems sh #(recip nthr)
 
 // #push-options "--z3rlimit_factor 4 --split_queries no --fuel 0 --ifuel 0 --query_stats"
 // #restart-solver

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.TensorCore2D.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.TensorCore2D.fst
@@ -6,26 +6,20 @@ open Kuiper
 #set-options "--ifuel 1 --initial_fuel 0 --max_fuel 1"
 #set-options "--z3rlimit 60"
 
-open Pulse.Lib.Array
-open Pulse.Lib.Trade
-open Kuiper.Matrix.Reprs.Type
-open Kuiper.Math { even, odd, even_2x, odd_2x1 }
+open Kuiper.Approximates
 open Kuiper.Array.Vectorized { has_vec_cpy, chunk }
-open Kuiper.Matrix
 open Kuiper.EMatrix { ematrix }
-open Kuiper.VArray {
-  varray,
-  varray_pts_to,
-  varray_pts_to_cell
-}
-open Kuiper.TensorCore
 open Kuiper.Float16
+open Kuiper.Math { even, odd, even_2x, odd_2x1 }
+open Kuiper.Matrix
+open Kuiper.Matrix.Reprs.Type
 open Kuiper.Matrix.Tiling
 open Kuiper.Poly.GEMM.Copy.Vec
 open Kuiper.Poly.GEMM.Tiled.Common.Vec
-
-open Kuiper.Approximates
 open Kuiper.Spec.GEMM
+open Kuiper.TensorCore
+open Pulse.Lib.Array
+open Pulse.Lib.Trade
 
 module SZ = Kuiper.SizeT
 module B = Kuiper.Barrier
@@ -813,7 +807,9 @@ fn kf
     gpu **
     kpre gA eA gB eB gC eC bm bn bk tm tn tk wm wn fA fB rA rB rC nthr sh bid tid **
     thread_id nthr tid **
-    block_id (rows/bm * (cols/bn)) bid
+    block_id (rows/bm * (cols/bn)) bid **
+    B.barrier_tok (FB.contract eA eB (R.row_major bm bk) (R.row_major bk bn) (fst sh) (fst (snd sh)) nthr bid) **
+    B.barrier_state 0
   ensures
     gpu **
     kpost gA eA gB eB gC eC bm bn bk tm tn tk wm wn fA fB rA rB rC nthr sh bid tid **
@@ -825,8 +821,6 @@ fn kf
 
   gpu_pts_to_ref sarA;
   gpu_pts_to_ref sarB;
-
-  unfold FB.barrier_tok eA eB (R.row_major bm bk) (R.row_major bk bn) sarA sarB nthr bid;
 
   gpu_matrix_abs' (R.row_major bm bk) sarA;
   let sA = from_array (R.row_major bm bk) sarA;
@@ -896,42 +890,48 @@ fn kf
     assert pure (even (2 * !bkIdx));
 
     #set-options "--z3rlimit 100 --retry 3" {
-    rewrite
-        (exists* em1. FB.bp_sharing sA em1 nthr) **
-        (exists* em2. FB.bp_sharing sB em2 nthr)
-      as FB.barrier_p eA eB sA sB nthr bid (2 * !bkIdx) tid;
+    // Silly intermediate step
+    rewrite (exists* em1. FB.bp_sharing sA em1 nthr) **
+            (exists* em2. FB.bp_sharing sB em2 nthr)
+         as (FB.barrier_p eA eB sA sB nthr bid) (2 * !bkIdx) tid;
+    rewrite (FB.barrier_p eA eB sA sB nthr bid) (2 * !bkIdx) tid
+         as (FB.contract eA eB (R.row_major bm bk) (R.row_major bk bn) sarA sarB nthr bid).rin (2 * !bkIdx) tid;
     };
 
     B.barrier_wait ();
-    rewrite FB.barrier_q eA eB sA sB nthr bid (2 * !bkIdx) tid
-        as live_strided_chunks sA nthr tid **
-           live_strided_chunks sB nthr tid;
+
+    // Again silly intermediate step
+    rewrite (FB.contract eA eB (R.row_major bm bk) (R.row_major bk bn) sarA sarB nthr bid).rout (2 * !bkIdx) tid
+         as (FB.barrier_q eA eB sA sB nthr bid) (2 * !bkIdx) tid;
+    rewrite (FB.barrier_q eA eB sA sB nthr bid) (2 * !bkIdx) tid
+         as live_strided_chunks sA nthr tid **
+            live_strided_chunks sB nthr tid;
 
     copy_tiles_out_of_matrices_vec bm bn bk sA sB gA gB mrow !bkIdx mcol (bm/^(wm*^tm)*^(bn/^(wn*^tn))*^warp_sz) tid;
 
     odd_2x1 !bkIdx;
     assert (pure (odd (2 * !bkIdx + 1)));
-    (* sigh.. *)
     #set-options "--z3rlimit 100 --retry 3" {
+    // Silly intermediate step
     rewrite own_strided_chunks sA (ematrix_subtile eA bm bk mrow !bkIdx) nthr tid **
             own_strided_chunks sB (ematrix_subtile eB bk bn !bkIdx mcol) nthr tid
-         as FB.barrier_p eA eB sA sB nthr bid (2 * !bkIdx + 1) tid;
+         as (FB.barrier_p eA eB sA sB nthr bid) (2 * !bkIdx + 1) tid;
+    rewrite (FB.barrier_p eA eB sA sB nthr bid) (2 * !bkIdx + 1) tid
+         as (FB.contract eA eB (R.row_major bm bk) (R.row_major bk bn) sarA sarB nthr bid).rin (2 * !bkIdx + 1) tid;
     };
 
     B.barrier_wait ();
 
     even_2x (!bkIdx + 1);
-    #set-options "--z3refresh --z3rlimit_factor 2 --fuel 0 --ifuel 0" {
-      assert pure (2 * (!bkIdx + 1) == 2 * !bkIdx + 2);
-      assert pure (odd (2 * !bkIdx + 1));
-      assert pure ((2 * !bkIdx + 1) < 2 * shared / bk);
-      assert pure (even (2 * !bkIdx + 2))
-    };
-    rewrite
-      FB.barrier_q eA eB sA sB nthr bid (2 * !bkIdx + 1) tid
-    as
-      FB.bp_sharing sA (ematrix_subtile eA bm bk mrow !bkIdx) nthr **
-      FB.bp_sharing sB (ematrix_subtile eB bk bn !bkIdx mcol) nthr;
+    assert pure (2 * (!bkIdx + 1) == 2 * !bkIdx + 2);
+    assert pure (odd (2 * !bkIdx + 1));
+    assert pure ((2 * !bkIdx + 1) < 2 * shared / bk);
+    assert pure (even (2 * !bkIdx + 2));
+    rewrite (FB.contract eA eB (R.row_major bm bk) (R.row_major bk bn) sarA sarB nthr bid).rout (2 * !bkIdx + 1) tid
+         as (FB.barrier_q eA eB sA sB nthr bid) (2 * !bkIdx + 1) tid;
+    rewrite (FB.barrier_q eA eB sA sB nthr bid) (2 * !bkIdx + 1) tid
+         as FB.bp_sharing sA (ematrix_subtile eA bm bk mrow !bkIdx) nthr **
+            FB.bp_sharing sB (ematrix_subtile eB bk bn !bkIdx mcol) nthr;
 
     unfold FB.bp_sharing sA (ematrix_subtile eA bm bk mrow !bkIdx) nthr;
     unfold FB.bp_sharing sB (ematrix_subtile eB bk bn !bkIdx mcol) nthr;
@@ -1023,20 +1023,6 @@ fn kf
   gpu_matrix_concr sA; rewrite each core sA as sarA;
   gpu_matrix_concr sB; rewrite each core sB as sarB;
 
-  #set-options "--z3rlimit 100 --retry 3" {
-    rewrite
-      B.barrier_tok (FB.barrier_p eA eB sA sB nthr bid)
-        (FB.barrier_q eA eB sA sB nthr bid)
-    as
-      B.barrier_tok (FB.barrier_p eA eB (from_array (R.row_major (v bm) (v bk)) sarA)
-            (from_array (R.row_major (v bk) (v bn)) sarB)
-            nthr bid)
-        (FB.barrier_q eA eB (from_array (R.row_major (v bm) (v bk)) sarA)
-            (from_array (R.row_major (v bk) (v bn)) sarB)
-            nthr bid);
-    fold FB.barrier_tok eA eB (R.row_major bm bk) (R.row_major bk bn) sarA sarB nthr bid;
-  };
-
   rewrite each sarA as fst sh;
   rewrite each sarB as fst (snd sh);
 
@@ -1048,6 +1034,10 @@ fn kf
             0 (warp_tile_j #rows #cols bm bn bk tm tn tk wm wn nthr bid (tid / warp_size)));
 
   fold_c_shmems sh (`%shmems_desc);
+
+  drop_ (B.barrier_state _);
+  drop_ (B.barrier_tok _);
+
   ()
 }
 
@@ -1119,6 +1109,9 @@ let mk_kernel
   nthr;
 
   shmems_desc = shmems_desc et_ab bm bn bk;
+
+  barrier_contract = (fun bid ptrs -> FB.contract eA eB (R.row_major bm bk) (R.row_major bk bn) (fst ptrs) (fst (snd ptrs)) nthr bid);
+  barrier_ok = (fun bid ptrs -> FB.barrier_p_to_q_transform eA eB (R.row_major bm bk) (R.row_major bk bn) (fst ptrs) (fst (snd ptrs)) nthr bid);
 
   frame = pure (SZ.fits (mlayout_size (R.row_major rows cols)));
   block_pre  = (fun bid -> forall+ (tid : natlt nthr). kpre1  gA eA gB eB gC eC bm bn bk tm tn tk wm wn fA fB rA rB rC nthr bid tid);

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.Tiled.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.Tiled.fst
@@ -190,7 +190,7 @@ fn teardown
   admit();
 }
 
-(* No need to do anything special here, just skip the barrier *)
+(* No op *)
 ghost
 fn block_setup
   (nblk : nat)
@@ -199,14 +199,12 @@ fn block_setup
   (bid : natlt nblk)
   norewrite
   requires
-    can_create_barrier nthr **
     p bid
   ensures
-    consumed_can_create_barrier **
     p bid **
     emp
 {
-  no_mk_barrier ();
+  ();
 }
 
 #push-options "--z3rlimit 40"


### PR DESCRIPTION
This gets rid of the `can_create_barrier` and
`consume_can_create_barrier` which are used to restrict barrier creation to the `block_setup` phase.  CUDA (block-wide) barriers are very intrinsic to kernels, so it makes sense to bake this into the kernel description, where one can of course decide to use a trivial empty barrier if there is no actual use for one.

This also vectorizes the shmem loading phase of TensorCore (non 2D), as I was touching that code anyway.