### PR TITLE
Fix verification regressions from universe SMT encoding changes

### DIFF
--- a/src/lib/data/Kuiper.Matrix4.fst
+++ b/src/lib/data/Kuiper.Matrix4.fst
@@ -58,6 +58,37 @@ let clayout4_bij
 }
 #pop-options
 
+#push-options "--z3rlimit 20 --fuel 0 --ifuel 0"
+let clayout4_imap_inj
+  (#mrows #mcols #brows #bcols : erased nat)
+  (#l : mlayout4 mrows mcols brows bcols)
+  (c : clayout4 l)
+  (idx1 idx2 : cit l)
+  : squash (clayout4_imap c idx1 == clayout4_imap c idx2 ==> idx1 == idx2)
+  = let (bi1, bj1, i1, j1) = idx1 in
+    let (bi2, bj2, i2, j2) = idx2 in
+    introduce clayout4_imap c idx1 == clayout4_imap c idx2 ==> idx1 == idx2
+    with _. (
+      // clayout4_imap uses c_to (s_undivmod ...) (s_undivmod ...)
+      // c_to i j  has  SZ.v result == l.map.f (SZ.v i, SZ.v j)
+      // So equal outputs imply equal l.map.f inputs (since SZ.v is injective on SZ.t)
+      // By l.map injectivity, the nat-level inputs are equal
+      // By s_divmod_inv_2, the original SZ.t tuples are equal
+      let r1 = SZ.v (s_undivmod c.c_brows (bi1, i1)) in
+      let c1 = SZ.v (s_undivmod c.c_bcols (bj1, j1)) in
+      let r2 = SZ.v (s_undivmod c.c_brows (bi2, i2)) in
+      let c2 = SZ.v (s_undivmod c.c_bcols (bj2, j2)) in
+      l.map.is_inj (r1, c1) (r2, c2);
+      // Now we have: (r1, c1) == (r2, c2), i.e. the s_undivmod values are equal
+      // By s_divmod_inv_2 (SMT patterns), s_divmod inverts s_undivmod
+      // so (bi1, i1) == (bi2, i2) and (bj1, j1) == (bj2, j2)
+      s_divmod_inv_2 c.c_brows (bi1, i1);
+      s_divmod_inv_2 c.c_brows (bi2, i2);
+      s_divmod_inv_2 c.c_bcols (bj1, j1);
+      s_divmod_inv_2 c.c_bcols (bj2, j2)
+    )
+#pop-options
+
 #push-options "--z3rlimit 80 --split_queries always"
 [@@"core"]
 inline_for_extraction noextract
@@ -68,6 +99,7 @@ instance cview_from_clayout4
   (#l : mlayout4 mrows mcols brows bcols)
   (c : clayout4 l)
   : IView.ciview (aview_from_mlayout et l).iview =
+  let _ = full_layout_size l in
 {
   clen = c.parent.m_rows *^ c.parent.m_cols;
 
@@ -77,7 +109,7 @@ instance cview_from_clayout4
   };
 
   step = {
-    cimap = mk_cinj (clayout4_imap c) #(fun idx1 idx2 -> ());
+    cimap = mk_cinj #_ #(szlt (l.len)) (clayout4_imap c) #(clayout4_imap_inj c);
     compat = ez;
   };
 }

--- a/src/lib/inst/gemm/Kuiper.GEMM.BlockTiling2D.Inst.fst
+++ b/src/lib/inst/gemm/Kuiper.GEMM.BlockTiling2D.Inst.fst
@@ -83,6 +83,18 @@ fn spec
   assert pure (aligned_strided_row_major (chunk et)
                 (Kuiper.Matrix.Reprs.strided_row_major_base #(SZ.v shared) #(SZ.v cols)));
 
+  // Prove rows/bm * (cols/bn) <= max_blocks from rows * cols <= max_blocks
+  // Since bm >= 1 and bn >= 1: rows/bm <= rows and cols/bn <= cols
+  FStar.Math.Lemmas.lemma_div_mod (SZ.v rows) (SZ.v bm);
+  FStar.Math.Lemmas.nat_over_pos_is_nat (SZ.v rows) (SZ.v bm);
+  FStar.Math.Lemmas.lemma_div_mod (SZ.v cols) (SZ.v bn);
+  FStar.Math.Lemmas.nat_over_pos_is_nat (SZ.v cols) (SZ.v bn);
+  assert pure (SZ.v rows / SZ.v bm <= SZ.v rows);
+  assert pure (SZ.v cols / SZ.v bn <= SZ.v cols);
+  FStar.Math.Lemmas.lemma_mult_le_right (SZ.v cols / SZ.v bn) (SZ.v rows / SZ.v bm) (SZ.v rows);
+  FStar.Math.Lemmas.lemma_mult_le_left (SZ.v rows) (SZ.v cols / SZ.v bn) (SZ.v cols);
+  assert pure (SZ.v rows / SZ.v bm * (SZ.v cols / SZ.v bn) <= SZ.v rows * SZ.v cols);
+
   P.mmcomb_gpu_exact
     (fun o n -> mul beta o `add` mul alpha n)
     #rows #shared #cols

--- a/src/lib/poly/gemm/Kuiper.Poly.GEMM.OrigBlockTiling1D.Setup.fst
+++ b/src/lib/poly/gemm/Kuiper.Poly.GEMM.OrigBlockTiling1D.Setup.fst
@@ -121,6 +121,8 @@ fn setup
                    ((bid % mcols) * bn + (tid % bn))));
 
   (* Step 6: Bridge to SizeT and match kpre1 *)
+  assert pure (SZ.v (mrows `SZ.mul` mcols) == mrows * mcols);
+  assert pure (SZ.v (bm /^ tm *^ bn) == bm/tm * bn);
   forevery_rw_size2
     (mrows * mcols) (mrows *^ mcols)
     (bm/tm * bn) (bm /^ tm *^ bn);


### PR DESCRIPTION
Three files regressed after the fstar2_remove_ulevel_nat_axiom merge:

1. Kuiper.Matrix4.fst: The implicit injection proof (fun idx1 idx2 -> ()) for clayout4_imap timed out. Fix: factor out an explicit clayout4_imap_inj lemma that chains l.map.is_inj with s_divmod_inv_2, add explicit type annotation #(szlt l.len) to guide elaboration, and call full_layout_size to establish l.len == rows * cols.

2. Kuiper.GEMM.BlockTiling2D.Inst.fst: The non-linear arithmetic fact rows/bm * (cols/bn) <= max_blocks could no longer be solved by SMT. Fix: add explicit FStar.Math.Lemmas calls (lemma_div_mod, nat_over_pos_is_nat, lemma_mult_le_right/left) to prove rows/bm <= rows and cols/bn <= cols, then chain the inequalities.

3. Kuiper.Poly.GEMM.OrigBlockTiling1D.Setup.fst: The SizeT-to-nat bridge equalities for forevery_rw_size2 were not provable. Fix: add explicit assertions that SZ.v (mrows * mcols) == mrows * mcols and SZ.v (bm /^ tm *^ bn) == bm/tm * bn.