### PR TITLE
Advance F* after upstreaming Kuiper patches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
     - main
   pull_request:
+  # Merge queues test the queued changes on a synthetic branch. This event is
+  # required for the protected `ciok` check to run on that branch.
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
     inputs:
       debug:

--- a/verify.mk
+++ b/verify.mk
@@ -132,6 +132,7 @@ FSTAR_FLAGS += --ext kuiper
 FSTAR_FLAGS += --ext __unrefine
 FSTAR_FLAGS += --ext no_krml_private
 # FSTAR_FLAGS += --ext core_phase2
+FSTAR_FLAGS += --ext pulse:extra_simplify
 FSTAR_FLAGS += --warn_error -288 # using has_type (we only use it in SMT patterns)
 FSTAR_FLAGS += --warn_error -271 # arithmetic (+,-,*,/) in SMT patterns, benign & unavoidable in foundational lemmas
 # FSTAR_FLAGS += --ext krml_inline_all


### PR DESCRIPTION
## Summary

- advance the F* submodule after upstreaming several local patches
- enable the Pulse extra-simplification extension
- run the required CI workflow for merge-queue groups

This PR is stacked on #93. Once both are green, the merge queue can validate this branch against the latest main without a manual update/rebase.

## Testing

- GitHub Actions CI