### PR TITLE
Use full_default() instead of exact (`1.0R) for permission binders

### DIFF
--- a/src/lib/data/Kuiper.Tensor.fst
+++ b/src/lib/data/Kuiper.Tensor.fst
@@ -69,7 +69,7 @@ let tensor_pts_to
   (#et : Type0) (#r : nat) (#d : shape r)
   (#l : tlayout d)
   ([@@@mkey] a : tensor et l)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (s : chest d et)
   : slprop
   = A.varray_pts_to a #f s
@@ -366,7 +366,7 @@ let tensor_pts_to_cell
   (#et : Type0) (#r : nat) (#d : shape r)
   (#l : tlayout d)
   ([@@@mkey] a : tensor et l)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   ([@@@mkey] i : abs d)
   (v : et)
   : slprop
@@ -381,7 +381,7 @@ unfold
 let tcell (#et : Type0) (#r : nat) (#d : shape r)
   (#l : tlayout d)
   (a : tensor et l)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (i : abs d)
   (v : et)
   : slprop

--- a/src/lib/data/Kuiper.Tensor.fsti
+++ b/src/lib/data/Kuiper.Tensor.fsti
@@ -15,7 +15,6 @@ open Pulse.Lib.Trade
 open Kuiper.Shareable
 
 module SZ = Kuiper.SizeT
-module T = FStar.Tactics.V2
 
 inline_for_extraction noextract
 val tensor (et : Type0) (#r : nat) (#d : shape r) (l : tlayout d) : Type0
@@ -108,7 +107,7 @@ val tensor_pts_to
   (#et : Type0) (#r : nat) (#d : shape r)
   (#l : tlayout d)
   ([@@@mkey] a : tensor et l)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (s : chest d et)
   : slprop
 
@@ -352,7 +351,7 @@ val tensor_pts_to_cell
   (#et : Type0) (#r : nat) (#d : shape r)
   (#l : tlayout d)
   ([@@@mkey] a : tensor et l)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   ([@@@mkey] i : abs d)
   (v : et)
   : slprop

--- a/src/lib/data/Kuiper.TensorRO.fst
+++ b/src/lib/data/Kuiper.TensorRO.fst
@@ -17,7 +17,6 @@ module IA = Kuiper.IArray
 module IV = Kuiper.IView
 module KT = Kuiper.Tensor
 module SZ = Kuiper.SizeT
-module T = FStar.Tactics.V2
 module Trade = Pulse.Lib.Trade
 
 (* ------------------------------------------------------------------------ *)
@@ -109,7 +108,7 @@ let tensor_pts_to
   (#et : Type0) (#r : nat) (#d : shape r)
   (#l : vtlayout d)
   ([@@@mkey] a : rotensor et l)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (s : chest d et)
   : slprop
   = exists* (v : natlt (vtlayout_ulen l) -> GTot et).
@@ -331,7 +330,7 @@ let tensor_pts_to_cell
   (#et : Type0) (#r : nat) (#d : shape r)
   (#l : vtlayout d)
   ([@@@mkey] a : rotensor et l)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   ([@@@mkey] i : abs d)
   (v : et)
   : slprop

--- a/src/lib/data/Kuiper.TensorRO.fsti
+++ b/src/lib/data/Kuiper.TensorRO.fsti
@@ -15,7 +15,6 @@ open Pulse.Lib.Trade
 open Kuiper.Shareable
 
 module SZ = Kuiper.SizeT
-module T = FStar.Tactics.V2
 
 [@@erasable]
 noeq
@@ -115,7 +114,7 @@ val tensor_pts_to
   (#et : Type0) (#r : nat) (#d : shape r)
   (#l : vtlayout d)
   ([@@@mkey] a : rotensor et l)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (s : chest d et)
   : slprop
 
@@ -279,7 +278,7 @@ val tensor_pts_to_cell
   (#et : Type0) (#r : nat) (#d : shape r)
   (#l : vtlayout d)
   ([@@@mkey] a : rotensor et l)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   ([@@@mkey] i : abs d)
   (v : et)
   : slprop

--- a/src/lib/data/array/Kuiper.IArray.fst
+++ b/src/lib/data/array/Kuiper.IArray.fst
@@ -56,7 +56,7 @@ let iarray_pts_to_cell
   (#et:Type0)
   (#vw : aiview)
   ([@@@mkey] a : iarray et vw)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   ([@@@mkey]i : vw.ait)
   (v : et)
   : slprop
@@ -76,7 +76,7 @@ let iarray_pts_to_cell_def
 let iarray_pts_to
   (#et:Type0) (#vw : aiview)
   ([@@@mkey] a : iarray et vw)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (v : (vw.ait -> GTot et))
   : slprop
   = pure (SZ.fits (len vw)) **

--- a/src/lib/data/array/Kuiper.IArray.fsti
+++ b/src/lib/data/array/Kuiper.IArray.fsti
@@ -5,7 +5,6 @@ inline_for_extraction noextract let x = 1
 open Kuiper
 open Kuiper.Bijection
 open Kuiper.IView
-module T = FStar.Tactics.V2
 module SZ = Kuiper.SizeT
 
 let oplus (#a #b : Type) (f : a -> GTot b) (x : a) (y : b) : a -> GTot b =
@@ -59,7 +58,7 @@ val iarray_pts_to_cell
   (#et:Type)
   (#vw : aiview)
   ([@@@mkey] a : iarray et vw)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   ([@@@mkey]i : vw.ait)
   (v : et)
   : slprop
@@ -84,7 +83,7 @@ instance cell_pts_to (#et : Type) (#vw : aiview)
 val iarray_pts_to
   (#et:Type0) (#vw : aiview)
   ([@@@mkey] a : iarray et vw)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (v : (vw.ait -> GTot et))
   : slprop
 

--- a/src/lib/data/array/Kuiper.VArray.fst
+++ b/src/lib/data/array/Kuiper.VArray.fst
@@ -61,7 +61,7 @@ let varray_pts_to_cell
   (#et #st : Type0)
   (#vw : aview et st)
   ([@@@mkey] a : varray vw)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   ([@@@mkey]i : vw.iview.ait)
   (v : et)
   : slprop
@@ -87,7 +87,7 @@ let varray_pts_to_cell_eq
 unfold
 let vcell (#et #st : Type) (#vw : aview et st)
   (a : varray vw)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (i : vw.iview.ait)
   (v : et)
   : slprop
@@ -110,7 +110,7 @@ let unfold_varray_cell () : T.Tac unit =
 let varray_pts_to
   (#et:Type0) (#st:_) (#vw : aview et st)
   ([@@@mkey] a : varray vw)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (v : st)
   : slprop
   =

--- a/src/lib/data/array/Kuiper.VArray.fsti
+++ b/src/lib/data/array/Kuiper.VArray.fsti
@@ -9,7 +9,6 @@ include Kuiper.View
 open Kuiper
 open Kuiper.Bijection
 open Kuiper.View
-module T = FStar.Tactics.V2
 module SZ = Kuiper.SizeT
 
 let view_equiv (#et #st : Type)
@@ -71,7 +70,7 @@ val varray_pts_to_cell
   (#et:Type)
   (#st:Type0) (#vw : aview et st)
   ([@@@mkey] a : varray vw)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   ([@@@mkey]i : vw.iview.ait)
   (v : et)
   : slprop
@@ -97,7 +96,7 @@ instance cell_pts_to (#et #st : Type) (#vw : aview et st)
 val varray_pts_to
   (#a:Type) (#st:_) (#vw : aview a st)
   ([@@@mkey] a : varray vw)
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (v : st)
   : slprop
 

--- a/src/lib/kuiper/Kuiper.Array.Core.fst
+++ b/src/lib/kuiper/Kuiper.Array.Core.fst
@@ -90,7 +90,7 @@ fn init_array_model_ghost
 let pts_to_slice
   (#a:Type u#0)
   ([@@@mkey] x : array a)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   ([@@@mkey] i : nat)
   (j : nat)
   (v : seq a)
@@ -191,7 +191,7 @@ fn add_full_slice
 //   (#a:Type u#0)
 //   (#sz:nat)
 //   ([@@@mkey] x:gpu_array a sz)
-//   (#[exact (`1.0R)] f : perm)
+//   (#[full_default ()] f : perm)
 //   ([@@@mkey] i : nat)
 //   (j : nat)
 //   (v : seq a)
@@ -208,7 +208,7 @@ fn add_full_slice
 instance is_send_pts_to
   (#a:Type u#0)
   (x : array a)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (v : seq a)
   : is_send_across
       (visibility_of x)
@@ -218,7 +218,7 @@ instance is_send_pts_to
 instance is_send_pts_to_slice
   (#a:Type u#0)
   ([@@@mkey] x : array a)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   ([@@@mkey] i : nat)
   (j : nat)
   (v : seq a)
@@ -635,7 +635,7 @@ ghost
 fn slice_concat
   (#a:Type u#0)
   (arr : array a)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (#s1 #s2: erased (seq a))
   (i n m:nat)
   requires pts_to_slice arr #f i n s1 ** pts_to_slice arr #f n m s2
@@ -652,7 +652,7 @@ ghost
 fn slice_split
   (#a:Type u#0)
   (arr : array a)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (#s1 #s2: erased (seq a))
   (i n m:nat)
   requires pts_to_slice arr #f i m (s1 @+ s2) ** pure (i <= n /\ n <= m /\ (i + Seq.length s1 == n \/ n + Seq.length s2 == m))

--- a/src/lib/kuiper/Kuiper.Array.Core.fsti
+++ b/src/lib/kuiper/Kuiper.Array.Core.fsti
@@ -66,7 +66,7 @@ let aligned' (n:pos)
 val pts_to_slice
   (#a:Type u#0)
   ([@@@mkey] x : array a)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   ([@@@mkey] i : nat)
   (j : nat)
   (v : seq a)
@@ -140,7 +140,7 @@ unfold
 let pts_to_cell
   (#a:Type u#0)
   ([@@@mkey] x : array a)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   ([@@@mkey] i : nat)
   (v : a)
 : slprop
@@ -152,7 +152,7 @@ let pts_to_cell
 //   (#a:Type u#0)
 //   (#sz:nat)
 //   ([@@@mkey] x : larray a sz)
-//   (#[exact (`1.0R)] f : perm)
+//   (#[full_default ()] f : perm)
 //   (v : seq a)
 // : slprop
 // =
@@ -161,7 +161,7 @@ let pts_to_cell
 instance val is_send_pts_to
   (#a:Type u#0)
   (x : array a)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (v : seq a)
   : is_send_across
       (visibility_of x)
@@ -170,7 +170,7 @@ instance val is_send_pts_to
 instance val is_send_pts_to_slice
   (#a:Type u#0)
   (x : array a)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (i j : nat)
   (v : seq a)
   : is_send_across
@@ -382,7 +382,7 @@ ghost
 fn slice_concat
   (#a:Type u#0)
   (arr : array a)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (#s1 #s2: erased (seq a))
   (i n m:nat)
   requires pts_to_slice arr #f i n s1 ** pts_to_slice arr #f n m s2
@@ -392,7 +392,7 @@ ghost
 fn slice_split
   (#a:Type u#0)
   (arr : array a)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (#s1 #s2: erased (seq a))
   (i n m:nat)
   requires pts_to_slice arr #f i m (s1 @+ s2) ** pure (i <= n /\ n <= m /\ (i + Seq.length s1 == n \/ n + Seq.length s2 == m))

--- a/src/lib/kuiper/Kuiper.Array.Derived.fst
+++ b/src/lib/kuiper/Kuiper.Array.Derived.fst
@@ -61,7 +61,7 @@ fn gpu_slice_split'
   (#a:Type u#0)
   (#sz:nat)
   (arr : larray a sz)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (#s : erased (seq a))
   (i n : nat)
   (#_ : squash (0 <= n-i /\ n-i < length s))

--- a/src/lib/kuiper/Kuiper.Array.Derived.fsti
+++ b/src/lib/kuiper/Kuiper.Array.Derived.fsti
@@ -47,7 +47,7 @@ pulse should only do weak unfolding. *)
 let gpu_pts_to_array1
   (#a:Type0)
   ([@@@mkey]arr : array a)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   ([@@@mkey]i:nat)
 : slprop =
   exists* s. pts_to_slice arr #f i (i+1) s
@@ -57,7 +57,7 @@ fn gpu_slice_split'
   (#a:Type u#0)
   (#sz:nat)
   (arr : larray a sz)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (#s : erased (seq a))
   (i n : nat)
   (#_ : squash (0 <= n-i /\ n-i < length s))

--- a/src/lib/kuiper/Kuiper.Ref.fst
+++ b/src/lib/kuiper/Kuiper.Ref.fst
@@ -18,7 +18,7 @@ inline_for_extraction noextract
 let gpu_pts_to
   (#a:Type u#0)
   ([@@@mkey]x:gpu_ref a)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (v : a)
   : slprop
   = Pulse.Lib.Array.pts_to x #f seq![v]

--- a/src/lib/kuiper/Kuiper.Ref.fsti
+++ b/src/lib/kuiper/Kuiper.Ref.fsti
@@ -15,7 +15,7 @@ inline_for_extraction noextract
 val gpu_pts_to
   (#a:Type u#0)
   ([@@@mkey]x:gpu_ref a)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (v : a)
 : slprop
 

--- a/src/lib/kuiper/Kuiper.SHMem.fst
+++ b/src/lib/kuiper/Kuiper.SHMem.fst
@@ -10,7 +10,6 @@ open Kuiper.Array
 open FStar.Tactics.V2
 open Kuiper.ForEvery
 open Kuiper.Common
-module T = FStar.Tactics
 
 //don't mark this an instance, to avoid clashing with other instances
 //for visibility_of, gpu_of
@@ -40,7 +39,7 @@ instance is_send_across_live_c_shmem #d (c:c_shmem d) #f (_:squash (c_shmem_inv 
     ff
 
 ghost
-fn unfold_live_c_shmems_nil (c : c_shmems []) (#[T.exact (`1.0R)]f:_)
+fn unfold_live_c_shmems_nil (c : c_shmems []) (#[full_default ()]f:_)
   requires live_c_shmems c #f
   ensures emp
 {
@@ -48,14 +47,14 @@ fn unfold_live_c_shmems_nil (c : c_shmems []) (#[T.exact (`1.0R)]f:_)
 }
 
 ghost
-fn fold_live_c_shmems_nil (c : c_shmems []) (#[T.exact (`1.0R)]f:_)
+fn fold_live_c_shmems_nil (c : c_shmems []) (#[full_default ()]f:_)
   ensures live_c_shmems c #f
 {
   rewrite emp as live_c_shmems c #f;
 }
 
 ghost
-fn unfold_live_c_shmems_cons #d #ds (c : c_shmems (d::ds)) (#[T.exact (`1.0R)]f:_)
+fn unfold_live_c_shmems_cons #d #ds (c : c_shmems (d::ds)) (#[full_default ()]f:_)
   requires live_c_shmems c #f
   ensures live_c_shmem #d (fst c) #f ** live_c_shmems #ds (snd c) #f
 {
@@ -64,7 +63,7 @@ fn unfold_live_c_shmems_cons #d #ds (c : c_shmems (d::ds)) (#[T.exact (`1.0R)]f:
 }
 
 ghost
-fn fold_live_c_shmems_cons #d #ds (c : c_shmems (d::ds)) (#[T.exact (`1.0R)]f:_)
+fn fold_live_c_shmems_cons #d #ds (c : c_shmems (d::ds)) (#[full_default ()]f:_)
 requires live_c_shmem #d (fst c) #f ** live_c_shmems #ds (snd c) #f
 ensures live_c_shmems c #f
 {

--- a/src/lib/kuiper/Kuiper.SHMem.fsti
+++ b/src/lib/kuiper/Kuiper.SHMem.fsti
@@ -11,7 +11,6 @@ open Kuiper.ForEvery
 open Kuiper.Common
 open Kuiper.Divides { (/?+) }
 module SZ = Kuiper.SizeT
-module T = FStar.Tactics
 module A = Pulse.Lib.Array
 
 (* Description of one shared memory array "request" *)
@@ -82,7 +81,7 @@ let c_shmems_inv (#ds : list shmem_desc) (c:c_shmems ds) : prop =
   c_shmems_block_inv c /\
   (exists (base:nat). 16 /?+ base /\ c_shmems_at c base)
 
-let live_c_shmem #d (c : c_shmem d) (#[T.exact (`1.0R)]f:_) : slprop =
+let live_c_shmem #d (c : c_shmem d) (#[full_default ()]f:_) : slprop =
   match d with
   | SHArray ty len ->
     exists* (v : Seq.seq ty).
@@ -91,7 +90,7 @@ let live_c_shmem #d (c : c_shmem d) (#[T.exact (`1.0R)]f:_) : slprop =
 instance val is_send_across_live_c_shmem #d (c:c_shmem d) #f (_:squash (c_shmem_inv c))
 : is_send_across block_of (live_c_shmem #d c #f)
 
-let rec live_c_shmems #ds (c : c_shmems ds) (#[T.exact (`1.0R)]f:_) : slprop =
+let rec live_c_shmems #ds (c : c_shmems ds) (#[full_default ()]f:_) : slprop =
   match ds with
   | [] -> emp
   | d :: ds ->
@@ -99,21 +98,21 @@ let rec live_c_shmems #ds (c : c_shmems ds) (#[T.exact (`1.0R)]f:_) : slprop =
     live_c_shmem #d (fst c) #f ** live_c_shmems #ds (snd c) #f
 
 ghost
-fn unfold_live_c_shmems_nil (c : c_shmems []) (#[T.exact (`1.0R)]f:_)
+fn unfold_live_c_shmems_nil (c : c_shmems []) (#[full_default ()]f:_)
   requires live_c_shmems c #f
   ensures emp
 
 ghost
-fn fold_live_c_shmems_nil (c : c_shmems []) (#[T.exact (`1.0R)]f:_)
+fn fold_live_c_shmems_nil (c : c_shmems []) (#[full_default ()]f:_)
   ensures live_c_shmems c #f
 
 ghost
-fn unfold_live_c_shmems_cons #d #ds (c : c_shmems (d::ds)) (#[T.exact (`1.0R)]f:_)
+fn unfold_live_c_shmems_cons #d #ds (c : c_shmems (d::ds)) (#[full_default ()]f:_)
   requires live_c_shmems c #f
   ensures live_c_shmem #d (fst c) #f ** live_c_shmems #ds (snd c) #f
 
 ghost
-fn fold_live_c_shmems_cons #d #ds (c : c_shmems (d::ds)) (#[T.exact (`1.0R)]f:_)
+fn fold_live_c_shmems_cons #d #ds (c : c_shmems (d::ds)) (#[full_default ()]f:_)
   requires live_c_shmem #d (fst c) #f ** live_c_shmems #ds (snd c) #f
   ensures live_c_shmems c #f
 

--- a/src/lib/kuiper/Kuiper.TensorCore.Base.fsti
+++ b/src/lib/kuiper/Kuiper.TensorCore.Base.fsti
@@ -10,7 +10,6 @@ open Kuiper.Array2.Strided
 open Kuiper.Chest
 open Kuiper.Spec.GEMM
 
-module T = FStar.Tactics.V2
 module SZ = Kuiper.SizeT
 
 type fragment_kind =
@@ -316,7 +315,7 @@ let array_fragment_pts_to
   (#m #n #k : nat)
   (#l : fragment_layout)
   ([@@@mkey] farr: array (fragment et knd m n k l))
-  (#[T.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (ems : seq (value_for et knd m n k))
   : slprop =
     // have to use lseq here otherwise the last line does not type check

--- a/src/lib/sparse/Kuiper.Sparse.Array.PtsTo.fst
+++ b/src/lib/sparse/Kuiper.Sparse.Array.PtsTo.fst
@@ -21,7 +21,7 @@ let slice_live
   (#et : Type0)
   (#l : nat)
   (a : larray et l)
-  (#[FStar.Tactics.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (i j : nat)
   : slprop
   = exists* s. pts_to_slice a #f i j s
@@ -30,7 +30,7 @@ let array_live_cell
   (#et : Type0)
   (#l : nat)
   (a : larray et l)
-  (#[FStar.Tactics.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (i : natlt l)
   : slprop
   // esto es medio choto
@@ -45,7 +45,7 @@ let pts_to_vec
   (#a:Type u#0) {| sized a, has_vec_cpy a |}
   (#sz:nat)
   ([@@@mkey] x:larray a sz)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   ([@@@mkey] i : nat)
   (v : seq a)
 : slprop
@@ -57,7 +57,7 @@ let pts_to_vec'
   (#a:Type) {| sized a, has_vec_cpy a |}
   (#sz:nat)
   ([@@@mkey] x:larray a sz)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   ([@@@mkey] i : nat)
   (v : seq a)
   (k : natle (len v - chunk a))
@@ -68,7 +68,7 @@ let live_vec
   (#a:Type) {| sized a, has_vec_cpy a |}
   (#l : nat)
   (x :larray a l)
-  (#[exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (i : nat)
 : slprop
 = exists* v. pts_to_vec x #f i v

--- a/src/lib/sparse/Kuiper.Sparse.Array.fst
+++ b/src/lib/sparse/Kuiper.Sparse.Array.fst
@@ -37,7 +37,7 @@ unfold
 let sarray_pts_to'
   (#et:Type0) {| d : scalar et |} (#l : nat)
   (a : sarray et l)
-  (#[Tactics.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (s : seq et)
   (v_elems : lseq et a.nnz)
   (v_pos   : lseq sz a.nnz)
@@ -52,7 +52,7 @@ let sarray_pts_to'
 let sarray_pts_to
   (#et:Type0) {| d : scalar et |} #l
   (a : sarray et l)
-  (#[Tactics.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (s : seq et)
   : slprop
 =

--- a/src/lib/sparse/Kuiper.Sparse.Matrix.fst
+++ b/src/lib/sparse/Kuiper.Sparse.Matrix.fst
@@ -134,7 +134,7 @@ let smatrix_pts_to'
   (#et:Type0) {| d : scalar et |}
   #rows #cols
   (m : smatrix et rows cols)
-  (#[Tactics.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (v_elems   : lseq et m.nnz)
   (v_col_ind : lseq sz m.nnz)
   (v_row_off : lseq sz (rows + 1))
@@ -152,7 +152,7 @@ let smatrix_pts_to
   (#et:Type0) {| d : scalar et |}
   #rows #cols
   (m : smatrix et rows cols)
-  (#[Tactics.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (e : chest2 et rows cols)
   : slprop
 =
@@ -170,7 +170,7 @@ fn unfold_smatrix
   (#et:Type0) {| d : scalar et |}
   #rows #cols
   (m : smatrix et rows cols)
-  (#[Tactics.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (e : chest2 et rows cols)
   requires smatrix_pts_to m #f e
   ensures
@@ -187,7 +187,7 @@ fn fold_smatrix
   (#et:Type0) {| d : scalar et |}
   #rows #cols
   (m : smatrix et rows cols)
-  (#[Tactics.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (v_elems    : lseq et m.nnz)
   (v_col_ind  : lseq sz m.nnz)
   (v_row_off  : lseq sz (rows + 1))
@@ -212,7 +212,7 @@ fn smatrix_share_n'
   (#et:Type0) {| d : scalar et |}
   #rows #cols
   (m : smatrix et rows cols)
-  (#[Tactics.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (v_elems   : lseq et m.nnz)
   (v_col_ind : lseq sz m.nnz)
   (v_row_off : lseq sz (rows + 1))
@@ -299,7 +299,7 @@ fn smatrix_gather_n'
   (#et:Type0) {| d : scalar et |}
   #rows #cols
   (m : smatrix et rows cols)
-  (#[Tactics.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (v_elems   : lseq et m.nnz)
   (v_col_ind : lseq sz m.nnz)
   (v_row_off : lseq sz (rows + 1))
@@ -410,7 +410,7 @@ fn gpu_array_cut
   (#a : Type u#0) {| sized a |}
   (#n : nat)
   (arr : larray a n)
-  (#[Tactics.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (k : szle n)
   (#s : lseq a n)
   requires
@@ -427,7 +427,7 @@ fn gpu_array_paste
   (#a : Type u#0) {| sized a |}
   (#n : nat)
   (arr : larray a n)
-  (#[Tactics.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (k : szle n)
   (#s : lseq a n)
   requires
@@ -444,7 +444,7 @@ fn gpu_array_paste'
   (#a : Type u#0) {| sized a |}
   (#n : nat)
   (arr : larray a n)
-  (#[Tactics.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (k : szle n)
   (#s : lseq a k) (#t : lseq a (n - k))
   requires
@@ -646,7 +646,7 @@ fn smatrix_extract
   (#et:Type0) {| scalar et |}
   (#rows #cols : szp)
   (m : smatrix et (SZ.v rows) (SZ.v cols))
-  (#[Tactics.exact (`1.0R)] f : perm)
+  (#[full_default ()] f : perm)
   (e : chest2 et rows cols)
   (i : szlt rows)
   requires


### PR DESCRIPTION
`Pulse.Class.PtsTo.full_default` is literally defined as ``exact (`1.0R)``, so this change is semantically a no-op. But F* master's `check_bqual` in `FStarC.TypeChecker.Core` compares binder meta-qualifiers *syntactically*, so writing the tactic out by hand doesn't match the `has_pts_to` class field and subtyping fails with:

```
Binder qualifier mismatch,
  Some #[fun _ -> FStar.Tactics.V2.Derived.exact (`1.0R)]
  vs Some #[fun _ -> Pulse.Class.PtsTo.full_default ()]
```

Our F* branch carries two patches to relax that check (`3989e8d8cd` "tweak in core tc" and `fb786bc8dc` "Core, disable matching meta qualifiers"). Spelling the default as `full_default ()` makes both unnecessary.

### Effect on building against upstream F*

Measured against unpatched upstream F* master (`3a7b92b441`):

| | before | after |
|---|---|---|
| `ADMIT=1` (typechecking only) | 266 / 396 | **396 / 396** |
| full verification | 158 / 396 | 163 / 396 |

23 of the 24 typechecking failures were this single cause. The 24th is the `noeq`+`unfold` on `has_vec_cpy` in `Kuiper.Array.Vectorized.fsti` (patch `38903e9149`), left alone here.

After this, the remaining upstream gap is purely SMT-level — `Kuiper.Divides`, `Kuiper.Tensor.Layout` and `Kuiper.EMatrix.Tiling` still want `5677117625` ("omit prop equations"), and `Kuiper.Kernel.GEMM.TensorCore2D.To.EpilogueLoopStep` regresses on upstream's new postcondition-pushing change (FStarLang/FStar#4508).

### Validation

- `make verify` with our current F*: **396/396 modules, 0 errors** — no regression.
- `make extract-all`: all 62 modules extract to CUDA unchanged.
- `make lint-fstar` passes; it removed the module abbreviations this made unused (hence 64 insertions / 72 deletions).

Extraction/`nvcc` is unaffected — the only build failures in my tree are the pre-existing CUDA 12.0 `__half` host/device errors in the hand-written F16 test drivers, which this diff doesn't touch.